### PR TITLE
Minor comment spelling correction "# Autoinstallation to insure.." to " ...

### DIFF
--- a/src/modules/IscsiClient.rb
+++ b/src/modules/IscsiClient.rb
@@ -302,7 +302,7 @@ module Yast
     end
 
     # Return packages needed to be installed and removed during
-    # Autoinstallation to insure module has all needed software
+    # Autoinstallation to ensure module has all needed software
     # installed.
     # @return [Hash] with 2 lists.
     def AutoPackages


### PR DESCRIPTION
Minor comment spelling correction "# Autoinstallation to insure.." to " # Autoinstallation to ensure.."
