### PR TITLE
try auto login bnc #876104

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  2 13:57:34 CEST 2014 - gs@suse.de
+
+- try auto login to target when called from partitioner
+  (bnc #876104)
+- 3.1.7
+
+-------------------------------------------------------------------
 Mon Apr 14 12:28:33 CEST 2014 - gs@suse.de
 
 - reintroduce exception in case of socket not found

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        3.1.6
+Version:        3.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClient.rb
+++ b/src/modules/IscsiClient.rb
@@ -208,6 +208,8 @@ module Yast
       #    Progress::NextStep();
       # read status of service
       return false if !IscsiClientLib.getServiceStatus
+      # try auto login to target
+      IscsiClientLib.autoLogOn
       Builtins.sleep(sl)
 
       # read current settings


### PR DESCRIPTION
So far IscsiClientLib.autoLogOn was only called in inst_iscsi-client.rb.
Patch was requested by Hannes to be able to configure iBFT intefaces also when iscsi-client is called from partitioner (Configure iSCSI disks) 
