### PR TITLE
Removed unnecessary BuildRequires dependencies

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 22 13:52:08 UTC 2014 - lslezak@suse.cz
+
+- removed unnecessary BuildRequires dependencies
+- 3.1.18
+
+-------------------------------------------------------------------
 Thu Sep 18 09:39:02 CEST 2014 - gs@suse.de
 
 - Add IP and port to 'isns' discovery command (bnc #897247)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        3.1.17
+Version:        3.1.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- the package still builds with `rake osc:build` :wink: 
