### PR TITLE
fix BNC#960386-yast-iscsi-client: start-up mode automatic get reset t…

### DIFF
--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -685,7 +685,7 @@ module Yast
 
       command = IscsiClientLib.GetDiscoveryCmd(ip, port,
                                                use_fw: false,
-                                               only_new: option_new)
+                                               only_new: TRUE)
       trg_list = runInBg(command)
       while !@bg_finish
 


### PR DESCRIPTION
Hi,
This patch can fix Bug 960386 - yast-iscsi-client: start-up mode "automatic" get reset to "manual" after re-discover the same target
