### PR TITLE
don't block AutoYaST install (bsc#981693)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 23 11:46:46 CEST 2016 - gs@suse.de
+
+- don't treat the attempt to login twice to a target as an error,
+  report a warning if login fails for other reasons (bsc#981693)
+- 3.1.29
+
+-------------------------------------------------------------------
 Tue Jun  7 10:45:54 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        3.1.28
+Version:        3.1.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1060,18 +1060,19 @@ module Yast
       )
       Builtins.y2internal("output %1", output)
 
-      if (output["exit"] || -1) != 0
-        Report.Error( _("Target connection failed.\n") +
-                      output["stderr"] || "" )
+      # Only log the fact that the session is already present (not an error at all)
+      # to avoid a popup for AutoYaST install (bsc#981693)
+      if output["exit"] == 15
+        Builtins.y2milestone("Session already present %1", output["stderr"] || "")
+      # Report a warning (not an error) if login failed for other reasons
+      # (also related to bsc#981693, warning popups usually are skipped)
+      elsif output["exit"] != 0
+        Report.Warning( _("Target connection failed.\n") +
+                        output["stderr"] || "" )
       end
-      # if (output["exit"]:-1==0){
-      # set startup status to auto by default (bnc#400610)
+
       setStartupStatus("onboot") if !Mode.autoinst
       true 
-      # } else {
-      # 	y2error("Error while Log-on into target : %1", output);
-      # 	return false;
-      # 	}
     end
 
 


### PR DESCRIPTION
This bug-fix solves the initial problem in bsc#981693 that an error popup blocks AutoYaST when trying to login to target twice.
The workaround is to delete the <iscsi-client> section from the xml-profile. The installation was successful then but hanged (still not solved) during network config. 
With the bug-fix the xml-profile generated with clone_system can be used. 