### PR TITLE
fix comparing iscsi node data (bsc#1119698)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar  1 13:36:35 UTC 2019 - snwint@suse.com
+
+- fix iBFT handling (bsc#1119698)
+- 4.1.5
+
+-------------------------------------------------------------------
 Thu Dec 13 16:42:21 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.1.4
+Version:        4.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -751,7 +751,15 @@ module Yast
     # @return  [Bool]    nodes are equal?
     #
     def equalNodes?(n1, n2)
-      return false if n1.empty?
+      return false if n1.empty? || n2.empty?
+
+      # we're going to modify one key...
+      n1 = n1.dup
+      n2 = n2.dup
+
+      # if unset, use default from /etc/iscsi/initiatorname.iscsi
+      n1["iface.initiatorname"] = @initiatorname if n1["iface.initiatorname"] == "<empty>"
+      n2["iface.initiatorname"] = @initiatorname if n2["iface.initiatorname"] == "<empty>"
 
       keys = [
         "iface.transport_name",

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -220,7 +220,7 @@ module Yast
         key, val = row.split("=")
 
         key = key.to_s.strip
-        retval[key] = val.to_s.strip if !key.empty?
+        retval[key] = val.to_s.strip if !key.empty? && !key.match?(/^#/)
       end
 
       retval

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -954,6 +954,8 @@ module Yast
         result = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m fw -l"))
         ret = false if result["exit"] != 0
         log.info "Autologin into iBFT : #{result}"
+        result = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m discovery -t fw"))
+        log.info "iBFT discovery: #{result}"
       end
       ret
     end

--- a/test/getiBFT_spec.rb
+++ b/test/getiBFT_spec.rb
@@ -27,16 +27,14 @@ describe Yast::IscsiClientLibClass do
         ibft_data = @iscsilib.getiBFT
 
         expect(ibft_data).to eq(
-          "# BEGIN RECORD 2.0-872" => "",
-          "# END RECORD"           => "",
-          "iface.bootproto"        => "STATIC",
-          "iface.hwaddress"        => "00:00:c9:b1:bc:7f",
-          "iface.initiatorname"    => "iqn.2011-05.com.emulex:eraptorrfshoneport1",
-          "iface.transport_name"   => "tcp",
-          "iface.ipaddress"        => "2620:0113:80c0:8000:000c:0000:0000:04dc",
-          "node.conn[0].address"   => "172.0.21.6",
-          "node.conn[0].port"      => "3260",
-          "node.name"              => "iqn.1986-03.com.ibm:sn.135061874"
+          "iface.bootproto"      => "STATIC",
+          "iface.hwaddress"      => "00:00:c9:b1:bc:7f",
+          "iface.initiatorname"  => "iqn.2011-05.com.emulex:eraptorrfshoneport1",
+          "iface.transport_name" => "tcp",
+          "iface.ipaddress"      => "2620:0113:80c0:8000:000c:0000:0000:04dc",
+          "node.conn[0].address" => "172.0.21.6",
+          "node.conn[0].port"    => "3260",
+          "node.name"            => "iqn.1986-03.com.ibm:sn.135061874"
         )
       end
     end


### PR DESCRIPTION
If iface.initiatorname is unset (as is usually the case, it seems) - replace
with value from /etc/iscsi/initiatorname.iscsi.