### PR TITLE
 IscsiClientLib: iscsiadm -m session exit status 21 is "success" 

### DIFF
--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -553,7 +553,7 @@ module Yast
           i,
           Ops.get_integer(cmd, "exit", -1)
         )
-        if Ops.get_integer(cmd, "exit", -1) == 0
+        if Ops.get_integer(cmd, "exit", -1) == 0 || Ops.get_integer(cmd, "exit", -1) == 21
           Builtins.y2internal("Good response from daemon, exit.")
           break
         end

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -21,6 +21,7 @@
 # | you may find current contact information at www.novell.com
 # |
 # |***************************************************************************
+# File: modules/IscsiClientLib.rb
 require "yast"
 require "yast2/systemd/socket"
 require "ipaddr"


### PR DESCRIPTION
When configuring iSCSI during installation with YaST, there are long wait times where apparently nothing happens.

In part, this is caused by waiting pointlessly for "iscsiadm -m session" to terminate with exit status 0, although the "normal" exit status in this situation is 21.