### PR TITLE
iscsiadm may have exit code 21 on success (bsc#1131049)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 16 11:17:12 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- iscsiadm may have exit code 21 on success (bsc#1131049)
+- 4.2.0
+
+-------------------------------------------------------------------
 Wed Mar 27 11:44:33 UTC 2019 - jsrain@suse.cz
 
 - further fixes of iscsiadm output parsing (bsc#1129946)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.1.7
+Version:        4.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -548,12 +548,10 @@ module Yast
       10.times do |i|
         Builtins.sleep(1 * 1000)
         cmd = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m session"))
-        Builtins.y2internal(
-          "iteration %1, retcode %2",
-          i,
-          Ops.get_integer(cmd, "exit", -1)
-        )
-        if Ops.get_integer(cmd, "exit", -1) == 0
+        Builtins.y2internal("iteration %1, retcode %2", i, cmd["exit"])
+        # Both exit codes 0 and 21 may indicate success.
+        # See discussion in bsc#1131049.
+        if [0, 21].include?(cmd["exit"])
           Builtins.y2internal("Good response from daemon, exit.")
           break
         end


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1131049

When configuring iSCSI YaST runs into a timeout waiting for `iscsiadm` to succeed at several places. As it happens, `iscsiadm` may return 21 to indicate success.

### Scrum board

https://trello.com/c/m4bAAjig

### Solution

See the long discussion in [bsc#1131049](https://bugzilla.suse.com/show_bug.cgi?id=1131049) for details. In essence, simply accept that `iscsiadm` may exit with 21 to mean success.

### See also

Closed older PR: https://github.com/yast/yast-iscsi-client/pull/82