### PR TITLE
[Backport]  Fix typo in #getServiceStatus (bsc#1103681 and bsc#1157349)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ config.sub
 configure
 configure.ac
 configure.in
+coverage
 install-sh
 Makefile
 Makefile.in

--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 13 14:46:40 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Fix detection of service current status (bsc#1157349).
+- 3.1.32
+
+-------------------------------------------------------------------
 Fri Nov 09 12:34:19 CET 2018 - aschnell@suse.com
 
 - removed onboot startup mode for LUNs on S/390 (bsc#1045139)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        3.1.31
+Version:        3.1.32
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1084,6 +1084,11 @@ module Yast
     end
 
 
+    # FIXME: this method has too much responsibility and it is doing
+    # "unexpected" things according to its name. Ideally, only must to return
+    # the service status without change the status of related services and
+    # sockets.
+    #
     # get status of iscsid
     def getServiceStatus
       ret = true
@@ -1104,7 +1109,7 @@ module Yast
         log.info "Status of iscsi.service: #{@iscsi_service_stat}, iscsid.socket: #{@iscsid_socket_stat}, iscsiuio.socket: #{@iscsiuio_socket_stat}"
 
         # if not running, start iscsi.service, iscsid.socket and iscsiuio.socket
-        if !@iscid_socket_stat
+        if !@iscsid_socket_stat
           Service.Stop("iscsid") if Service.active?("iscsid") 
           log.error "Cannot start iscsid.socket" if !socketStart(@iscsid_socket)
         end

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -1,0 +1,71 @@
+require_relative "test_helper"
+
+require_relative "../src/modules/IscsiClientLib"
+
+describe Yast::IscsiClientLibClass do
+  subject { described_class.new }
+
+  describe "#getServiceStatus" do
+    let(:iscsid_socket) { double("iscsid.socket", start: true) }
+
+    before do
+      allow(Yast::Service).to receive(:Stop).with(anything)
+      allow(Yast::Service).to receive(:active?).with(anything)
+      allow(Yast::SystemdSocket).to receive(:find!).with(anything)
+      allow(subject).to receive(:socketActive?)
+      allow(subject.log).to receive(:error)
+    end
+
+    context "when iscsid.socket and iscsid.service are active" do
+      before do
+        allow(Yast::Service).to receive(:active?).with("iscsid").and_return(true)
+        allow(Yast::SystemdSocket).to receive(:find!).with("iscsid").and_return(iscsid_socket)
+        allow(subject).to receive(:socketActive?).with(iscsid_socket).and_return(true)
+      end
+
+      it "does nothing" do
+        expect(iscsid_socket).to_not receive(:start)
+        expect(Yast::Service).to_not receive(:Stop).with("iscsid")
+
+        subject.getServiceStatus
+      end
+    end
+
+    context "when iscsid.socket is not active" do
+      before do
+        allow(Yast::SystemdSocket).to receive(:find!).with("iscsid").and_return(iscsid_socket)
+        allow(subject).to receive(:socketActive?).with(iscsid_socket).and_return(false)
+      end
+
+      context "and socket is availbale" do
+        it "start iscsid.socket" do
+          expect(iscsid_socket).to receive(:start)
+
+          subject.getServiceStatus
+        end
+
+        context "but iscsid.service is active" do
+          before do
+            allow(Yast::Service).to receive(:active?).with("iscsid").and_return(true)
+          end
+
+          it "stop iscsid.service" do
+            expect(Yast::Service).to receive(:Stop).with("iscsid")
+
+            subject.getServiceStatus
+          end
+        end
+      end
+
+      context "but socket is not availbale" do
+        let(:iscsid_socket) { nil }
+
+        it "logs an error" do
+          expect(subject.log).to receive(:error).with("Cannot start iscsid.socket")
+
+          subject.getServiceStatus
+        end
+      end
+    end
+  end
+end

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -6,8 +6,6 @@ describe Yast::IscsiClientLibClass do
   subject { described_class.new }
 
   describe "#getServiceStatus" do
-    let(:iscsid_socket) { double("iscsid.socket", start: true) }
-
     before do
       allow(Yast::Service).to receive(:Stop).with(anything)
       allow(Yast::Service).to receive(:active?).with(anything)
@@ -16,54 +14,60 @@ describe Yast::IscsiClientLibClass do
       allow(subject.log).to receive(:error)
     end
 
-    context "when iscsid.socket and iscsid.service are active" do
-      before do
-        allow(Yast::Service).to receive(:active?).with("iscsid").and_return(true)
-        allow(Yast::SystemdSocket).to receive(:find!).with("iscsid").and_return(iscsid_socket)
-        allow(subject).to receive(:socketActive?).with(iscsid_socket).and_return(true)
-      end
+    context "for iscsid.socket" do
+      let(:iscsid_socket) { double("iscsid.socket", start: true) }
 
-      it "does nothing" do
-        expect(iscsid_socket).to_not receive(:start)
-        expect(Yast::Service).to_not receive(:Stop).with("iscsid")
-
-        subject.getServiceStatus
-      end
-    end
-
-    context "when iscsid.socket is not active" do
       before do
         allow(Yast::SystemdSocket).to receive(:find!).with("iscsid").and_return(iscsid_socket)
-        allow(subject).to receive(:socketActive?).with(iscsid_socket).and_return(false)
+        allow(subject).to receive(:socketActive?).with(iscsid_socket).and_return(socket_status)
       end
 
-      context "and socket is availbale" do
-        it "start iscsid.socket" do
-          expect(iscsid_socket).to receive(:start)
+      context "when iscsid.socket and iscsid.service are active" do
+        let(:socket_status) { true }
+
+        before do
+          allow(Yast::Service).to receive(:active?).with("iscsid").and_return(true)
+        end
+
+        it "does not start the socket nor the service" do
+          expect(iscsid_socket).to_not receive(:start)
+          expect(Yast::Service).to_not receive(:Stop).with("iscsid")
 
           subject.getServiceStatus
         end
+      end
 
-        context "but iscsid.service is active" do
-          before do
-            allow(Yast::Service).to receive(:active?).with("iscsid").and_return(true)
-          end
+      context "when iscsid.socket is not active" do
+        let(:socket_status) { false }
 
-          it "stop iscsid.service" do
-            expect(Yast::Service).to receive(:Stop).with("iscsid")
+        context "and socket is availbale" do
+          it "starts iscsid.socket" do
+            expect(iscsid_socket).to receive(:start)
 
             subject.getServiceStatus
           end
+
+          context "but iscsid.service is active" do
+            before do
+              allow(Yast::Service).to receive(:active?).with("iscsid").and_return(true)
+            end
+
+            it "stops iscsid.service" do
+              expect(Yast::Service).to receive(:Stop).with("iscsid")
+
+              subject.getServiceStatus
+            end
+          end
         end
-      end
 
-      context "but socket is not availbale" do
-        let(:iscsid_socket) { nil }
+        context "but socket is not availbale" do
+          let(:iscsid_socket) { nil }
 
-        it "logs an error" do
-          expect(subject.log).to receive(:error).with("Cannot start iscsid.socket")
+          it "logs an error" do
+            expect(subject.log).to receive(:error).with("Cannot start iscsid.socket")
 
-          subject.getServiceStatus
+            subject.getServiceStatus
+          end
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,33 @@
+srcdir = File.expand_path("../../src", __FILE__)
+y2dirs = ENV.fetch("Y2DIR", "").split(":")
+ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
+
+require "yast"
+require "yast/rspec"
+
+# Ensure the tests runs with english locales
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+RSpec.configure do |c|
+  c.extend Yast::I18n # available in context/describe
+  c.include Yast::I18n
+end
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  # track all ruby files under src
+  SimpleCov.track_files("#{srcdir}/**/*.rb")
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end


### PR DESCRIPTION
### :memo: A backport of #69 

---

This PR fix a typo checking the status of `iscsid.socket` which forces to always stop the service and start the socket.

It was reported and fixed for SLE-15 [(bsc#1103681)](https://bugzilla.suse.com/show_bug.cgi?id=1103681) and now is requested  [(bsc#1157349)](https://bugzilla.novell.com/show_bug.cgi?id=1157349#c16) to backport the fix also for SLE-12-SP4/5