### PR TITLE
Service default action

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  9 08:47:18 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Keep the current service state after writing the configuration by
+  default (bsc#1160374).
+- 4.2.3
+
+-------------------------------------------------------------------
 Thu Aug 22 16:57:36 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 Group:          System/YaST

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -357,7 +357,12 @@ module Yast
     #
     # @return [::CWM::ServiceWidget]
     def service_widget
-      @service_widget ||= ::CWM::ServiceWidget.new(IscsiClient.services)
+      return @service_widget if @service_widget
+
+      @service_widget = ::CWM::ServiceWidget.new(IscsiClient.services)
+      # Do not touch the service after writing the config (bsc#1160374).
+      @service_widget.default_action = :nothing
+      @service_widget
     end
 
     # main tabbed dialog


### PR DESCRIPTION
## Problem

Recently and as consequence of this [PR](https://github.com/yast/yast-yast2/pull/999) we have changed the default service action after writing the configuration. 

In the case of the iscsi-client, the service should not be touched at all.

- https://bugzilla.novell.com/show_bug.cgi?id=1160374

## Solution

Propose `:nothing` as the default_action for the service widget.

## Screenshots

### Current state

![RestartByDefault](https://user-images.githubusercontent.com/7056681/72053116-4e79c680-32be-11ea-9bf5-8fd63e0f2633.png)

### Do nothing by default (proposed fix)

![DoNothingByDefault](https://user-images.githubusercontent.com/7056681/72053122-50438a00-32be-11ea-999a-c94ad1bf74f7.png)