### PR TITLE
Backport discovery fix

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 17 10:17:29 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- fix calling iscsiadm on interface (bsc#1158443)
+- 4.1.8
+
+-------------------------------------------------------------------
 Wed Mar 27 11:44:33 UTC 2019 - jsrain@suse.cz
 
 - further fixes of iscsiadm output parsing (bsc#1129946)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.1.7
+Version:        4.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -930,7 +930,7 @@ module Yast
         path(".target.bash_output"),
         GetAdmCmd(
           Builtins.sformat(
-            "-m node -I%3 -T %1 -p %2 --op=update --name=node.conn[0].startup --value=%4",
+            "-m node -I %3 -T %1 -p %2 --op=update --name=node.conn[0].startup --value=%4",
             Ops.get(@currentRecord, 1, "").shellescape,
             Ops.get(@currentRecord, 0, "").shellescape,
             Ops.get(@currentRecord, 2, "default").shellescape,
@@ -1132,7 +1132,7 @@ module Yast
           if Ops.greater_than(Builtins.size(ifacepar), 0)
             ifacepar = Ops.add(ifacepar, " ")
           end
-          ifacepar = Ops.add(Ops.add(ifacepar, "-I "), iface)
+          ifacepar = Ops.add(Ops.add(ifacepar, "-I "), iface.shellescape)
           ifaces = Builtins.add(ifaces, iface)
         end
       end
@@ -1148,7 +1148,7 @@ module Yast
             GetAdmCmd(
               Builtins.sformat(
                 "-m discovery %1 -t st -p %2",
-                ifacepar.shellescape,
+                ifacepar,
                 Ops.get_string(target, "portal", "").shellescape
               )
             )

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1128,13 +1128,11 @@ module Yast
       ifacepar = ""
       Builtins.foreach(Ops.get_list(@ay_settings, "targets", [])) do |target|
         iface = Ops.get_string(target, "iface", "default")
-        if !Builtins.contains(ifaces, iface)
-          if Ops.greater_than(Builtins.size(ifacepar), 0)
-            ifacepar = Ops.add(ifacepar, " ")
-          end
-          ifacepar = Ops.add(Ops.add(ifacepar, "-I "), iface.shellescape)
-          ifaces = Builtins.add(ifaces, iface)
-        end
+        next if ifaces.include?(iface) # already added
+
+        ifacepar << " " unless ifacepar.empty?
+        ifacepar << "-I " << iface.shellescape
+        ifaces << iface
       end
       if Ops.greater_than(Builtins.size(Builtins.filter(ifaces) do |s|
                                           s != "default"

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -73,4 +73,29 @@ describe Yast::IscsiClientLibClass do
       end
     end
   end
+
+  describe ".autoyastWrite" do
+    it "calls iscsiadm discovery" do
+      subject.ay_settings = {
+        "targets" => [
+          { "iface" => "eth0", "portal" => "magic" },
+          { "iface" => "eth1", "portal" => "portal 1" }
+        ]
+      }
+
+      allow(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), anything)
+        .and_return("exit" => 0, "stdout" => "", "stderr" => "")
+
+      expect(Yast::SCR).to receive(:Execute).with(
+        Yast::Path.new(".target.bash"),
+        "LC_ALL=POSIX /sbin/iscsiadm -m discovery -I eth0 -I eth1 -t st -p magic"
+      )
+      expect(Yast::SCR).to receive(:Execute).with(
+        Yast::Path.new(".target.bash"),
+        "LC_ALL=POSIX /sbin/iscsiadm -m discovery -I eth0 -I eth1 -t st -p portal\\ 1"
+      )
+
+      subject.autoyastWrite
+    end
+  end
 end


### PR DESCRIPTION
backport of https://github.com/yast/yast-iscsi-client/pull/90 no other branches are affected as bug is caused by shell escaping done in SP1.