### PR TITLE
Backport of Knut changes in 4.2.3 to fix bsc#1160374

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 29 14:26:18 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed bsc#1162078 by backporting Knut's fix for bsc#1160374 from
+  version 4.2.3: keep the current state after writing the
+  configuration by default.
+- 4.1.9
+
+-------------------------------------------------------------------
 Fri Jan 17 10:17:29 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - fix calling iscsiadm on interface (bsc#1158443)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.1.8
+Version:        4.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -357,7 +357,12 @@ module Yast
     #
     # @return [::CWM::ServiceWidget]
     def service_widget
-      @service_widget ||= ::CWM::ServiceWidget.new(IscsiClient.services)
+      return @service_widget if @service_widget
+
+      @service_widget = ::CWM::ServiceWidget.new(IscsiClient.services)
+      # Do not touch the service after writing the config (bsc#1160374).
+      @service_widget.default_action = :nothing
+      @service_widget
     end
 
     # main tabbed dialog


### PR DESCRIPTION
The behavior of the service widget was changed for SLE-15-SP2 (and Tumbleweed) in https://github.com/yast/yast-yast2/pull/999

That broke yast-iscsi-client, which was fixed (also for SLE-15-SP2 and TW) via https://github.com/yast/yast-iscsi-client/pull/89

But afterwards, the new behavior of the widget was backported to SLE-15-SP1. See https://github.com/yast/yast-yast2/pull/1001

As a consequence, the yast-iscsi-client fix from #89 also needs to be backported to SLE-15-SP1 (reported as [bsc#1162078](https://bugzilla.suse.com/show_bug.cgi?id=1162078)). That's exactly what the current pull request is about. Check the original pull request for details about what is changed and why.