### PR TITLE
Change services order

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 10 09:29:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Handle the iscsi service status (restart, start...) change after
+  the iscsid and the iscsiuio sockets (bsc#1160606)
+- 4.1.10
+
+-------------------------------------------------------------------
 Wed Jan 29 14:26:18 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed bsc#1162078 by backporting Knut's fix for bsc#1160374 from

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.1.9
+Version:        4.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/IscsiClient.rb
+++ b/src/modules/IscsiClient.rb
@@ -76,10 +76,16 @@ module Yast
     #
     # @return [Yast2::CompundService]
     def services
+      # TODO: Having a combination of services and sockets in a compoud service
+      #   do not smell very well and the user might be very carefull on the
+      #   'after reboot' selection having to choose correctly for enabling the
+      #   desired option (bsc#1160606).
       @services ||= Yast2::CompoundService.new(
-        Yast2::SystemService.find("iscsi"),
         Yast2::SystemService.find("iscsid"),
-        Yast2::SystemService.find("iscsiuio")
+        Yast2::SystemService.find("iscsiuio"),
+        # It seems that moving it to the end help when iscsid socket is active
+        # and need to be restarted.
+        Yast2::SystemService.find("iscsi")
       )
     end
 

--- a/src/modules/IscsiClient.rb
+++ b/src/modules/IscsiClient.rb
@@ -84,7 +84,7 @@ module Yast
         Yast2::SystemService.find("iscsid"),
         Yast2::SystemService.find("iscsiuio"),
         # It seems that moving it to the end help when iscsid socket is active
-        # and need to be restarted.
+        # and need to be restarted. (bsc#853300, bsc#1160606)
         Yast2::SystemService.find("iscsi")
       )
     end


### PR DESCRIPTION
## Problem

An openQA test is failing because the iscsid.socket is expected to be running after restarting it but it is not.

It seems that the option for restarting the socket is not selected in the test and thus, the service is started instead of the socket, but, if selected correctly, there are situations where the socket is not started because the service was already running.

- https://trello.com/c/dpNmTxj4/1637-5-sles15-sp1-sp2-p5-1160606-build-1221-iscsidsocket-is-inactive-when-configure-target-with-yast-iscsi-client
- https://bugzilla.suse.com/show_bug.cgi?id=1160606#c15

## Solution

After some tests and checks, it seems that the iscsi service should be handled at the end of the **CompoundService** as it is done by getServiceStatus.

https://github.com/yast/yast-iscsi-client/blob/d2349fd00a05424fab73690b79f7c1061e092113/src/modules/IscsiClientLib.rb#L1071

- Move the 'iscsi' service at the end of the CompoudService.

## Tests

- tested manually