### PR TITLE
Explain why Startup combobox is disabled

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 20 13:55:46 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Help text to clarify the behavior of the Startup widget when
+  iBFT is detected (bsc#1170317).
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue May 12 08:50:23 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 Group:          System/YaST

--- a/src/include/iscsi-client/helps.rb
+++ b/src/include/iscsi-client/helps.rb
@@ -44,6 +44,9 @@ module Yast
                "root is on iSCSI. As such it will be evaluated by the initrd.</p>\n") if !Arch.s390
         x += _("<p><b>automatic</b> is for iSCSI targets to be connected when the iSCSI service\n" \
                "starts up.</p>\n")
+        x += _("<p>When iBFT (iSCSI Boot Firmware Table) is used, the startup mode of the\n" \
+               "node is irrelevant. For that reason, the widget is disabled if iBFT is\n" \
+               "detected by YaST.</p>\n")
         x
       end
 


### PR DESCRIPTION
When connecting to an iSCSI target using iBFT, the start-up mode is irrelevant and, as consequence, it was decided a long time ago that YaST should display the corresponding widget as blocked with the value "onboot". See all the details here: https://bugzilla.suse.com/show_bug.cgi?id=954509

But that intentional behavior was reported recently as [bug#1170317](https://bugzilla.suse.com/show_bug.cgi?id=1170317). As using an iBFT device for non-booting purposes is admittedly a corner case and finding a best solution is not easy (the mount point is unknown when the device is configured), it was decided to just improve the help text to mitigate the situation.

|  result in text mode | result in Qt |
|---|---|
| ![help-ncurses](https://user-images.githubusercontent.com/3638289/82456900-19c01c00-9ab5-11ea-9296-b422ca508d67.png) | ![help-qt](https://user-images.githubusercontent.com/3638289/82456898-188eef00-9ab5-11ea-9a3f-526d5e8ece89.png) |

