### PR TITLE
Cherry pick of #100: Explain why Startup combobox is disabled

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 20 13:55:46 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Help text to clarify the behavior of the Startup widget when
+  iBFT is detected (bsc#1170317).
+- 4.2.6
+
+-------------------------------------------------------------------
 Tue Mar 10 09:29:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Handle the iscsi service status (restart, start...) change after

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 Group:          System/YaST

--- a/src/include/iscsi-client/helps.rb
+++ b/src/include/iscsi-client/helps.rb
@@ -44,6 +44,9 @@ module Yast
                "root is on iSCSI. As such it will be evaluated by the initrd.</p>\n") if !Arch.s390
         x += _("<p><b>automatic</b> is for iSCSI targets to be connected when the iSCSI service\n" \
                "starts up.</p>\n")
+        x += _("<p>When iBFT (iSCSI Boot Firmware Table) is used, the startup mode of the\n" \
+               "node is irrelevant. For that reason, the widget is disabled if iBFT is\n" \
+               "detected by YaST.</p>\n")
         x
       end
 


### PR DESCRIPTION
As a fix (or mitigation, to be more precise) for [bug#1170317](https://bugzilla.suse.com/show_bug.cgi?id=1170317), an extension of the help text was implemented for the master branch at #100 (see that pull request for details and screenshots).

But @jsrain asked us in the mentioned  [bug#1170317](https://bugzilla.suse.com/show_bug.cgi?id=1170317) to submit that new text to SLE-15-SP2 as well. This pull request cherry-picks the changes from #100 to incorporate them in the SLE-15-SP2 branch.