### PR TITLE
Add iface element

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  3 09:32:29 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the 'iface' element to the AutoYaST schema (bsc#1182193).
+- 4.2.7
+
+-------------------------------------------------------------------
 Wed May 20 13:55:46 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Help text to clarify the behavior of the Startup widget when

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 Group:          System/YaST

--- a/src/autoyast-rnc/iscsi-client.rnc
+++ b/src/autoyast-rnc/iscsi-client.rnc
@@ -15,7 +15,8 @@ iscsi-client = element iscsi-client {
             element startup     { text }? &
             element target      { text }? &
             element username    { text }? &
-            element username_in { text }?
+            element username_in { text }? &
+            element iface       { text }?
         }*
     }? &
     element version { text }?


### PR DESCRIPTION
Add the 'iface' element to the AutoYaST schema. According to [this piece of code](https://github.com/yast/yast-iscsi-client/blob/674e0cf58c8bf769b27e343125973c9fa3c03a7d/src/include/iscsi-client/widgets.rb#L894-L914), it was the only missing element.

Bug: [bsc#1182193](https://bugzilla.suse.com/show_bug.cgi?id=1182193)
Trello: https://trello.com/c/QGvizs7U/