### PR TITLE
Add yast2-packager build runtime dependency

### DIFF
--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -26,6 +26,7 @@ Url:            https://github.com/yast/yast-iscsi-client
 
 Source0:        %{name}-%{version}.tar.bz2
 
+BuildRequires:  yast2-packager
 # Yast2::Systemd::Socket
 BuildRequires:  yast2 >= 4.1.3
 BuildRequires:  yast2 >= 2.23.15


### PR DESCRIPTION
Now that the tests are actually being executed in OBS (see #106), we need `yast2-packager` as a build time dependency.