### PR TITLE
adjust to ruby 3.0 (bsc#1195226)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 27 16:25:30 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- adjust to ruby 3.0 (bsc#1195226)
+- 4.4.3
+
+-------------------------------------------------------------------
 Thu Jul 22 08:30:10 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Add iscsi support for qedi/qede offload cards

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -410,7 +410,7 @@ module Yast
       Wizard.HideBackButton
       ret = CWM.Run(
         w,
-        :abort => fun_ref(method(:ReallyAbort), "boolean ()")
+        { :abort => fun_ref(method(:ReallyAbort), "boolean ()") }
       )
       ret
     end
@@ -448,7 +448,7 @@ module Yast
 
       ret = CWM.Run(
         w,
-        :abort => fun_ref(method(:ReallyAbort), "boolean ()")
+        { :abort => fun_ref(method(:ReallyAbort), "boolean ()") }
       )
       deep_copy(ret)
     end
@@ -473,7 +473,7 @@ module Yast
       )
       ret = CWM.Run(
         w,
-        :abort => fun_ref(method(:ReallyAbort), "boolean ()")
+        { :abort => fun_ref(method(:ReallyAbort), "boolean ()") }
       )
       deep_copy(ret)
     end
@@ -515,7 +515,7 @@ module Yast
 
       ret = CWM.Run(
         w,
-        :abort => fun_ref(method(:ReallyAbort), "boolean ()")
+        { :abort => fun_ref(method(:ReallyAbort), "boolean ()") }
       )
       deep_copy(ret)
     end


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1195226

Ruby 3.0 has slightly changed the method argument handling.

## See also

- https://ruby-doc.org/core-3.0.0/NEWS_md.html