### PR TITLE
Start iscsiuio only in presence of the relevant hardware (bsc#1194432)

### DIFF
--- a/src/clients/iscsi-client_finish.rb
+++ b/src/clients/iscsi-client_finish.rb
@@ -111,7 +111,6 @@ module Yast
       Builtins.y2milestone("enabling iscsiuio socket and service")
       socket = Yast2::Systemd::Socket.find("iscsiuio")
       socket.enable if socket
-      Service.Enable("iscsiuio")
     end
   end
 end

--- a/src/clients/iscsi-client_finish.rb
+++ b/src/clients/iscsi-client_finish.rb
@@ -110,7 +110,11 @@ module Yast
 
       Builtins.y2milestone("enabling iscsiuio socket and service")
       socket = Yast2::Systemd::Socket.find("iscsiuio")
-      socket.enable if socket
+      if socket
+        socket.enable
+      else
+        Service.Enable("iscsiuio")
+      end
     end
   end
 end

--- a/src/clients/iscsi-client_finish.rb
+++ b/src/clients/iscsi-client_finish.rb
@@ -87,10 +87,7 @@ module Yast
           # enable iscsi and iscsid service
           Service.Enable("iscsid")
           Service.Enable("iscsi")
-          Builtins.y2milestone("enabling iscsiuio socket and service")
-          socket = Yast2::Systemd::Socket.find("iscsiuio")
-          socket.enable if socket
-          Service.Enable("iscsiuio")
+          enable_iscsiuio
         end
       else
         Builtins.y2error("unknown function: %1", @func)
@@ -100,6 +97,21 @@ module Yast
       Builtins.y2debug("ret=%1", @ret)
       Builtins.y2milestone("iscsi-client_finish finished")
       deep_copy(@ret)
+    end
+
+  private
+
+    # Enables the iscsiuio service if needed
+    def enable_iscsiuio
+      if !IscsiClientLib.iscsiuio_relevant?
+        Builtins.y2milestone("iscsiuio is not needed")
+        return
+      end
+
+      Builtins.y2milestone("enabling iscsiuio socket and service")
+      socket = Yast2::Systemd::Socket.find("iscsiuio")
+      socket.enable if socket
+      Service.Enable("iscsiuio")
     end
   end
 end

--- a/src/modules/IscsiClient.rb
+++ b/src/modules/IscsiClient.rb
@@ -76,17 +76,11 @@ module Yast
     #
     # @return [Yast2::CompundService]
     def services
-      # TODO: Having a combination of services and sockets in a compoud service
+      # TODO: Having a combination of services and sockets in a compound service
       #   do not smell very well and the user might be very carefull on the
       #   'after reboot' selection having to choose correctly for enabling the
       #   desired option (bsc#1160606).
-      @services ||= Yast2::CompoundService.new(
-        Yast2::SystemService.find("iscsid"),
-        Yast2::SystemService.find("iscsiuio"),
-        # It seems that moving it to the end help when iscsid socket is active
-        # and need to be restarted. (bsc#853300, bsc#1160606)
-        Yast2::SystemService.find("iscsi")
-      )
+      @services ||= Yast2::CompoundService.new(system_services)
     end
 
     # Abort function
@@ -356,6 +350,18 @@ module Yast
     publish :function => :Summary, :type => "list ()"
     publish :function => :Overview, :type => "list ()"
     publish :function => :AutoPackages, :type => "map ()"
+
+  private
+
+    # @see #services
+    def system_services
+      list = [Yast2::SystemService.find("iscsid")]
+      list << Yast2::SystemService.find("iscsiuio") if IscsiClientLib.iscsiuio_relevant?
+      # It seems that moving it to the end helps when iscsid socket is active
+      # and need to be restarted. (bsc#853300, bsc#1160606)
+      list << Yast2::SystemService.find("iscsi")
+      list
+    end
   end
 
   IscsiClient = IscsiClientClass.new

--- a/src/modules/IscsiClient.rb
+++ b/src/modules/IscsiClient.rb
@@ -80,7 +80,7 @@ module Yast
       #   do not smell very well and the user might be very carefull on the
       #   'after reboot' selection having to choose correctly for enabling the
       #   desired option (bsc#1160606).
-      @services ||= Yast2::CompoundService.new(system_services)
+      @services ||= Yast2::CompoundService.new(*system_services)
     end
 
     # Abort function

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -55,13 +55,6 @@ module Yast
       @iface_file = {}
       @iface_eth = []
 
-      # status of iscsi.service
-      @iscsi_service_stat = false
-      # status of iscsid.socket
-      @iscsid_socket_stat = false
-      # status of iscsiuio.socket
-      @iscsiuio_socket_stat = false
-
       # Content of the main configuration file (/etc/iscsi/iscsid.conf)
       #
       # Due to the way YaST ini-agent works, this variable follows the structure
@@ -1092,22 +1085,22 @@ module Yast
         @iscsid_socket = Yast2::Systemd::Socket.find!("iscsid")
         @iscsiuio_socket = Yast2::Systemd::Socket.find!("iscsiuio")
 
-        @iscsi_service_stat = Service.active?("iscsi")
-        @iscsid_socket_stat = socketActive?(@iscsid_socket)
-        @iscsiuio_socket_stat = socketActive?(@iscsiuio_socket)
+        iscsi_service_stat = Service.active?("iscsi")
+        iscsid_socket_stat = socketActive?(@iscsid_socket)
+        iscsiuio_socket_stat = socketActive?(@iscsiuio_socket)
 
-        log.info "Status of iscsi.service: #{@iscsi_service_stat}, iscsid.socket: #{@iscsid_socket_stat}, iscsiuio.socket: #{@iscsiuio_socket_stat}"
+        log.info "Status of iscsi.service: #{iscsi_service_stat}, iscsid.socket: #{iscsid_socket_stat}, iscsiuio.socket: #{iscsiuio_socket_stat}"
 
         # if not running, start iscsi.service, iscsid.socket and iscsiuio.socket
-        if !@iscsid_socket_stat
+        if !iscsid_socket_stat
           Service.Stop("iscsid") if Service.active?("iscsid")
           log.error "Cannot start iscsid.socket" if !socketStart(@iscsid_socket)
         end
-        if !@iscsiuio_socket_stat
+        if !iscsiuio_socket_stat
           Service.Stop("iscsiuio") if Service.active?("iscsiuio")
           log.error "Cannot start iscsiuio.socket" if !socketStart(@iscsiuio_socket)
         end
-        if !@iscsi_service_stat && !Service.Start("iscsi")
+        if !iscsi_service_stat && !Service.Start("iscsi")
           log.error "Cannot start iscsi.service"
         end
       end

--- a/test/iscsi-client_finish_test.rb
+++ b/test/iscsi-client_finish_test.rb
@@ -35,7 +35,7 @@ describe Yast::IscsiClientFinishClient do
         expect(Yast::Service).to_not receive(:Enable)
 
         result = subject.main
-        expect(result).to be_nil 
+        expect(result).to be_nil
       end
     end
 

--- a/test/iscsi-client_finish_test.rb
+++ b/test/iscsi-client_finish_test.rb
@@ -63,6 +63,7 @@ describe Yast::IscsiClientFinishClient do
           it "enables iscsi service but not the iscsiuio service" do
             expect(Yast::Service).to receive(:Enable).with("iscsid")
             expect(Yast::Service).to receive(:Enable).with("iscsi")
+            allow_message_expectations_on_nil
             expect(iscsiuio_socket).to_not receive(:enable)
 
             subject.main

--- a/test/iscsi-client_finish_test.rb
+++ b/test/iscsi-client_finish_test.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require_relative "../src/clients/iscsi-client_finish"
+
+describe Yast::IscsiClientFinishClient do
+  subject { described_class.new }
+
+  describe "#main when func is 'Write'" do
+    before do
+      allow(Yast::WFM).to receive(:Args).with(no_args).and_return(args)
+      allow(Yast::WFM).to receive(:Args) { |n| n.nil? ? args : args[n] }
+
+      # Mock copying of the open-iscsi database to avoid side effects
+      allow(Yast::WFM).to receive(:Execute)
+
+      allow(Yast::IscsiClientLib).to receive(:sessions).and_return session
+      allow(Yast::IscsiClientLib).to receive(:iscsiuio_relevant?).and_return iscsiuio
+    end
+
+    let(:args) { ["Write"] }
+    let(:session) { false }
+
+    context "if there are no active iSCSI sessions" do
+      let(:session) { [] }
+
+      it "does not enable any service or socket" do
+        expect(Yast2::Systemd::Socket).to_not receive(:find)
+        expect(Yast::Service).to_not receive(:Enable)
+
+        result = subject.main
+        expect(result).to be_nil 
+      end
+    end
+
+    context "if there is any active iSCSI session" do
+      let(:session) { ["session0", "session1"] }
+
+      context "and iscsiuio may be relevant in this system" do
+        let(:session) { true }
+
+        context "and there is a systemd unit for the iscsiuio socket" do
+          it "enables iscsi service and the iscsiuio socket" do
+          end
+        end
+
+        context "but there is no systemd unit for the iscsiuio socket" do
+          it "enables iscsi service and the iscsiuio service" do
+          end
+        end
+      end
+
+      context "and iscsiuio is not relevant in this system" do
+        let(:session) { false }
+
+        it "enables iscsi service but not iscsiuio" do
+        end
+      end
+    end
+  end
+end

--- a/test/iscsi-client_finish_test.rb
+++ b/test/iscsi-client_finish_test.rb
@@ -48,9 +48,10 @@ describe Yast::IscsiClientFinishClient do
         context "and there is a systemd unit for the iscsiuio socket" do
           let(:iscsiuio_socket) { instance_double(Yast2::Systemd::Socket, enable: true) }
 
-          it "enables iscsi service and the iscsiuio socket" do
+          it "enables iscsi service and the iscsiuio socket but not the iscsiuio service" do
             expect(Yast::Service).to receive(:Enable).with("iscsid")
             expect(Yast::Service).to receive(:Enable).with("iscsi")
+            expect(Yast::Service).to_not receive(:Enable).with("iscsiuio")
             expect(iscsiuio_socket).to receive(:enable)
 
             subject.main
@@ -60,11 +61,10 @@ describe Yast::IscsiClientFinishClient do
         context "but there is no systemd unit for the iscsiuio socket" do
           let(:iscsiuio_socket) { nil }
 
-          it "enables iscsi service but not the iscsiuio service" do
+          it "enables iscsi service and the iscsiuio service" do
             expect(Yast::Service).to receive(:Enable).with("iscsid")
             expect(Yast::Service).to receive(:Enable).with("iscsi")
-            allow_message_expectations_on_nil
-            expect(iscsiuio_socket).to_not receive(:enable)
+            expect(Yast::Service).to receive(:Enable).with("iscsiuio")
 
             subject.main
           end

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -621,6 +621,54 @@ describe Yast::IscsiClientLib do
     end
   end
 
+  describe "#iscsiuio_relevant?" do
+    before do
+      allow(subject).to receive(:GetOffloadModules).and_return modules
+    end
+
+    context "there are no cards in the system supporting offloading" do
+      let(:modules) { [] }
+
+      it "returns false" do
+        expect(subject.iscsiuio_relevant?).to eq false
+      end
+    end
+
+    context "there are cards in the system supporting offloading" do
+      context "but none of them use the bnx2i or qedi modules" do
+        let(:modules) { ["fnic", "cxgb3i"] }
+
+        it "returns false" do
+          expect(subject.iscsiuio_relevant?).to eq false
+        end
+      end
+
+      context "and one of them uses de bnx2i module" do
+        let(:modules) { ["fnic", "cxgb3i", "bnx2i"] }
+
+        it "returns true" do
+          expect(subject.iscsiuio_relevant?).to eq true
+        end
+      end
+
+      context "and one of them uses de qedi module" do
+        let(:modules) { ["qedi"] }
+
+        it "returns true" do
+          expect(subject.iscsiuio_relevant?).to eq true
+        end
+      end
+
+      context "and there are cards using both bnx2i and qedi modules" do
+        let(:modules) { ["qedi", "cxgb3i", "bnx2i"] }
+
+        it "returns true" do
+          expect(subject.iscsiuio_relevant?).to eq true
+        end
+      end
+    end
+  end
+
   describe ".GetOffloadItems" do
     around(:each) do |example|
       # The directory /etc/iscsi/ifaces/ is always scanned to look for interface definitions,

--- a/test/iscsi_client_test.rb
+++ b/test/iscsi_client_test.rb
@@ -6,7 +6,13 @@ require_relative "../src/modules/IscsiClient"
 Yast.import "IscsiClient"
 
 describe Yast::IscsiClient do
-  subject(:iscsi_client) { described_class }
+  # Due to the tricky way in which YaST modules are implemented, this is needed to reset the
+  # instance variables of the module on every example.
+  subject(:iscsi_client) do
+    klass = Yast::IscsiClientClass.new
+    klass.main
+    klass
+  end
 
   before do
     allow(Yast2::SystemService).to receive(:find).with(anything).and_return(service)
@@ -18,16 +24,39 @@ describe Yast::IscsiClient do
   let(:commandline) { false }
 
   describe "#services" do
-    it "includes iscsi, iscsid, and iscsiuio" do
-      expect(Yast2::SystemService).to receive(:find).with("iscsi")
-      expect(Yast2::SystemService).to receive(:find).with("iscsid")
-      expect(Yast2::SystemService).to receive(:find).with("iscsiuio")
-
-      subject.services
+    before do
+      allow(Yast::IscsiClientLib).to receive(:iscsiuio_relevant?).and_return(iscsiuio)
     end
 
-    it "returns a compound service" do
-      expect(subject.services).to be_a(Yast2::CompoundService)
+    context "if any card in the system needs iscsiuio" do
+      let(:iscsiuio) { true }
+
+      it "includes iscsi, iscsid and iscsiuio" do
+        expect(Yast2::SystemService).to receive(:find).with("iscsi")
+        expect(Yast2::SystemService).to receive(:find).with("iscsid")
+        expect(Yast2::SystemService).to receive(:find).with("iscsiuio")
+
+        subject.services
+      end
+
+      it "returns a compound service" do
+        expect(subject.services).to be_a(Yast2::CompoundService)
+      end
+    end
+
+    context "if there are no cards in the system depending on iscsiuio" do
+      let(:iscsiuio) { false }
+
+      it "includes iscsi and iscsid" do
+        expect(Yast2::SystemService).to receive(:find).with("iscsi")
+        expect(Yast2::SystemService).to receive(:find).with("iscsid")
+
+        subject.services
+      end
+
+      it "returns a compound service" do
+        expect(subject.services).to be_a(Yast2::CompoundService)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

According to [bsc#1194432](https://bugzilla.suse.com/show_bug.cgi?id=1194432) YaST enables the `iscsiuio` daemon always when some iSCSI devices are configured. But `iscsiuio` is the userspace offloading daemon for QLogic (formerly Broadcom) devices, so it's only needed when hardware offloading is configured for a device using the `bnx2i` or `qedi` drivers. In any other case, enabling `iscsiuio` only makes the boot process slower with no gain.

On the other hand, the convoluted code of yast-iscsi-client makes very hard to understand and modify the management of services.

## Solution

This pull request includes a couple of preliminary cleanup commits that should not change how the module behave. Instead, those commits provide small code cleanups and a lot of inline documentation to help to understand how services are handled in different parts of the module.

This pull request also includes a subsequent commit ensuring the `iscsiuio` service and socket are only enabled/disabled if there is any card in the system that should be handled with the `bnx2i` or `qedi` kernel modules. The implemented logic does not take into account whether hardware offloading is configured for such devices or not, so it still could enable the service in situations in which is not strictly needed. Nevertheless, the change should help in many scenarios and it should imply a low risk to introduce regressions.

The way services are started/stopped is not modified, only how they are enabled/disabled.

## Testing

Existing unit tests should be adapted and new unit tests should be created.

So far, that's left as an exercise to whoever finishes this pull request.
