### PR TITLE
Version bump and changelog

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May 11 09:51:04 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Internal cleanup in several parts to turn the auto-converted YCP
+  code into something closer to common Ruby.
+- Enable iscsiuio during installation only if there is any card in
+  the system using the bnx2i or qedi modules (bsc#1194432).
+- 4.5.2
+
+-------------------------------------------------------------------
 Mon Apr 11 12:04:00 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use $PATH, not absolute paths for calling external programs

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

As part of an [effort to make easier to contribute](https://trello.com/c/eWOWDp1I/2915-5-iscsi-client-lower-the-bar) to this module (specially for @gonzoleeman but not only for him), we created these two pull requests:

- https://github.com/yast/yast-iscsi-client/pull/115
- https://github.com/yast/yast-iscsi-client/pull/116

But we didn't increase the version of the package during the process. That implies our continuous integration system will not auto-submit the changes to openSUSE Tumbleweed.

## Solution

Increase the version, so the package is submitted to Tumbleweed and we can get some feedback about the new `iscsiuio` handling and/or detect if something breaks with all the introduced changes (the mentioned pull requests include quite some code cleanup).
