### PR TITLE
Make it work in containers and stop using deprecated agent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,7 +100,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 1279
+  Max: 1282
 
 # Offense count: 21
 # Configuration parameters: IgnoredMethods.

--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jun 21 13:19:31 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Stop using the deprecated agent "background".
+- Ensure iSCSI discovery works when YaST is configuring a different
+  target system (bsc#1199840).
+- 4.5.4
+
+-------------------------------------------------------------------
 Mon May 16 10:11:13 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix a crash when opening the main dialog (bsc#1199552).

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -631,6 +631,12 @@ module Yast
       # targets won't change then (fate #317874, bnc #886796).
       option_new = (@current_tab == "client")
 
+      # The discovery command can take care of loading the needed kernel modules.
+      # But that doesn't work when YaST is running (and thus executing the
+      # discovery command) in a container. So this loads the modules in advance
+      # in a way that works in containers.
+      IscsiClientLib.load_modules
+
       command = IscsiClientLib.GetDiscoveryCmd(ip, port,
         use_fw:   false,
         only_new: option_new)

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -44,68 +44,47 @@ module Yast
 
     # Runs the given command in background with a timeout of 10 seconds
     #
-    # - If the command is invalid (eg. not available), it returns an empty array, sets
-    #   @stat to false... and also sets @bg_finish to false, which produces an infinite
-    #   loop at #validateServerLocation. Currently the commands passed to #runInBg are
-    #   always of the form "LC_ALL=posix whatever", which means /bin/sh is instantiated
-    #   thus the command is always found and this case never happens (pure luck).
-    # - In any other case, the method sets @bg_finish to true and returns the stdout of
-    #   the command. Additionally:
-    #   * If the command success, the method sets @stat to true.
-    #   * If the command fails, the method displays the first line of stderr to the user
-    #     and sets @stat to false.
-    #   * It the timeout is reached, the process is killed and the method displays a
-    #     message about the timeout to the user. The value of @stat is not modified.
+    # The method sets @bg_finish to true and returns the stdout of the command.
+    # Additionally:
+    #
+    # - If the command success, the method sets @stat to true.
+    # - If the command fails, the method displays the first line of stderr to the user
+    #   and sets @stat to false.
+    # - It the timeout is reached, the process is killed and the method displays a
+    #   message about the timeout to the user. The value of @stat is not modified.
     #
     # @return [Array<String>] each one of the lines of stdout
     def runInBg(command)
-      # NOTE: this method uses the "background" agent, deprecated in favor of "process".
       @bg_finish = false
       Builtins.y2milestone("Start command %1 in background", command)
       stdout = []
       return_code = nil
-      started = Convert.to_boolean(
-        SCR.Execute(path(".background.run_output_err"), command)
-      )
-      if !started
-        Builtins.y2error("Cannot run command")
-        @stat = false
-        return []
-      end
+
+      pid = SCR.Execute(path(".process.start_shell"), command)
       time_spent = 0
       cont_loop = true
       script_time_out = 10000
       sleep_step = 20
-      while cont_loop &&
-          Convert.to_boolean(SCR.Read(path(".background.output_open")))
-        if Ops.greater_or_equal(time_spent, script_time_out)
+
+      while cont_loop && SCR.Read(path(".process.running"), pid)
+        if time_spent >= script_time_out
           Popup.Error(_("Command timed out"))
           cont_loop = false
         end
-        time_spent = Ops.add(time_spent, sleep_step)
+        time_spent += sleep_step
         Builtins.sleep(sleep_step)
       end
+
       Builtins.y2milestone("Time spent: %1 msec", time_spent)
-      stdout = Convert.convert(
-        SCR.Read(path(".background.newout")),
-        :from => "any",
-        :to   => "list <string>"
-      )
+      stdout = (SCR.Read(path(".process.read"), pid) || "").split("\n")
       Builtins.y2milestone("Output: %1", stdout)
+
       if cont_loop
-        return_code = Convert.to_integer(SCR.Read(path(".background.status")))
+        return_code = SCR.Read(path(".process.status"), pid).to_i
         Builtins.y2milestone("Return: %1", return_code)
         if return_code != 0
           @stat = false
-          error = Ops.get(
-            Convert.convert(
-              SCR.Read(path(".background.newerr")),
-              :from => "any",
-              :to   => "list <string>"
-            ),
-            0,
-            ""
-          )
+          error = SCR.Read(path(".process.read_line_stderr"), pid)
           Builtins.y2error("Error: %1", error)
           Popup.Error(error)
         else
@@ -113,9 +92,7 @@ module Yast
         end
       else
         # killing the process if it still runs
-        if Convert.to_boolean(SCR.Read(path(".background.output_open")))
-          SCR.Execute(path(".background.kill"), "")
-        end
+        SCR.Execute(path(".process.kill"), pid)
       end
       @bg_finish = true
       deep_copy(stdout)

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -42,9 +42,24 @@ module Yast
       @bg_finish = false
     end
 
-    # string initiatorname="";
-    # function for run command in background
+    # Runs the given command in background with a timeout of 10 seconds
+    #
+    # - If the command is invalid (eg. not available), it returns an empty array, sets
+    #   @stat to false... and also sets @bg_finish to false, which produces an infinite
+    #   loop at #validateServerLocation. Currently the commands passed to #runInBg are
+    #   always of the form "LC_ALL=posix whatever", which means /bin/sh is instantiated
+    #   thus the command is always found and this case never happens (pure luck).
+    # - In any other case, the method sets @bg_finish to true and returns the stdout of
+    #   the command. Additionally:
+    #   * If the command success, the method sets @stat to true.
+    #   * If the command fails, the method displays the first line of stderr to the user
+    #     and sets @stat to false.
+    #   * It the timeout is reached, the process is killed and the method displays a
+    #     message about the timeout to the user. The value of @stat is not modified.
+    #
+    # @return [Array<String>] each one of the lines of stdout
     def runInBg(command)
+      # NOTE: this method uses the "background" agent, deprecated in favor of "process".
       @bg_finish = false
       Builtins.y2milestone("Start command %1 in background", command)
       stdout = []

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1121,7 +1121,7 @@ module Yast
     def getServiceStatus
       ret = true
       if Stage.initial
-        ModuleLoading.Load("iscsi_tcp", "", "", "", false, true)
+        load_modules
         # start daemon manually (systemd not available in inst-sys)
         start_services_initial
       else
@@ -1527,6 +1527,11 @@ module Yast
     # @return [Boolean]
     def iscsiuio_relevant?
       (ISCSIUIO_MODULES & GetOffloadModules()).any?
+    end
+
+    # Loads the kernel modules needed to configure the iscsi client
+    def load_modules
+      ModuleLoading.Load("iscsi_tcp", "", "", "", false, true)
     end
 
     publish :variable => :sessions, :type => "list <string>"


### PR DESCRIPTION
## Problem

When executing the module in a container, the discovery and connection of targets only worked if the kernel module `iscsi_tcp` was loaded in the host system. The command `iscsiadm` traditionally took care of loading that module if needed in a way that was transparent to YaST. But that mechanism does not work when YaST (and, thus, the `iscsiadm` command) is executed in a container.

Additionally, when diagnosing the problem it was found that the command `iscsiadm` was executed using the agent `.background` which is deprecated and left a lot of errors like this in the YaST logs:

```
WARNING: .background agent is obsoleted, use .process agent instead!
```

## Solution

- First of all, the method using the `.background` agent was documented and manually tested, since it exhibited a [pretty inconsistent and fragile behavior](https://github.com/yast/yast-iscsi-client/commit/0693f8529ecbabe2e6006bbe6d403a4867dffb6d#diff-f53fb4c533c2ce4128c0d79f7035317f2352bd59e93dfc438fac2d7fd9c57035R45).
- Then the method was rewritten to use `.process` and to be more robust. Manually verified it still works in the same way in all situations... except in the ones that were clearly wrong in the previous implementation (potentially leading to infinite loops).
- To fix the problem with containerization, now the `iscsi_tcp` kernel module is explicitly loaded before executing the `iscsiadm` command. That's done using the YaST mechanisms than ensure it works even in containerized environments.

## Testing

- Tested manually in many possible situations (even forcing de-installation of `iscsiadm`).