### PR TITLE
Call External Commands Without Path

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  2 17:03:48 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Call external commands without path (bsc#1204959)
+- 4.5.6
+
+-------------------------------------------------------------------
 Wed Oct  5 10:09:58 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - replace .process agent with running Execute to respect changed

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2iscsi_client/timeout_process.rb
+++ b/src/lib/y2iscsi_client/timeout_process.rb
@@ -19,7 +19,7 @@ module Y2IscsiClient
 
       # pass kill-after to ensure that command really dies even if ignore TERM
       stdout, stderr, exit_status = Yast::Execute.on_target!(
-        "/usr/bin/timeout", "--kill-after=5s", "#{seconds}s",
+        "timeout", "--kill-after=5s", "#{seconds}s",
         *command, stdout: :capture, stderr: :capture,
         allowed_exitstatus: 0..255, env: { "LC_ALL" => "POSIX" }
       )

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1500,7 +1500,7 @@ module Yast
     def GetDiscoveryCmd(ip, port, use_fw: false, only_new: false)
       Builtins.y2milestone("GetDiscoveryCmd ip:%1 port:%2 fw:%3 only new:%4",
         ip, port, use_fw, only_new)
-      command = ["/usr/sbin/iscsiadm", "-m", "discovery", "-P", "1"]
+      command = ["iscsiadm", "-m", "discovery", "-P", "1"]
       isns_info = useISNS
       if isns_info["use"]
         command << "-t" << "isns"


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1204959


## Trello

https://trello.com/c/sJaVnYvE/


## Problem

An external command `/usr/sbin/iscsiadm` could not be called, so probing for iSCSI hardware failed, so the whole module became unusable.


## Cause

During the _usr-merge_, many commands were moved from `/sbin` to `/usr/sbin` (and from `/bin` to `/usr/bin`), and we already did the migration in _master_ so _factory_ complied to the new standard.

But that meant that SLE-15 SP5, which inherits all YaST code from _master_, now failed with those external commands: Unlike _factory_, SLE-15 SPx does _not_ have any compatibility symlinks between `/sbin` and `/usr/sbin` (or `/bin` and `/usr/bin`), resulting in this _command not found_ error.


## Fix

As already discussed half a year ago, our new policy is to not use an absolute path for commands in standard system directories where we have a safe `$PATH` to anyway, and just invoke them as the plain command without a path.

Since we did the complete opposite migration not so long ago as the result of a security audit where we were told to always use a full path when invoking external commands, we now have a lot of places that we need to migrate.

Since the code in this YaST module already uses `Yast::Execute.on_target!()`, a safe `$PATH` is guaranteed. The only difference here is that the command is called with the `timeout` command (now also called without a full path, relying on `$PATH`) to ensure that it doesn't hang forever if the target hardware doesn't respond.

## Further Reading

**[Invoking External Commands in YaST](https://github.com/yast/yast-yast2/blob/master/doc/yast-invoking-external-commands.md)**
