### PR TITLE
Refactoring needed for D-Installer

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 10 16:29:34 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Expose all core functionality from IscsiClientLib, with options
+  to suppress usage of pop-ups (related t gh#yast/d-installer#402).
+
+-------------------------------------------------------------------
 Fri Feb 10 15:41:21 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Finish client: copy the content of both /etc/iscsi and

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -619,16 +619,7 @@ module Yast
         # delete connected item
         if Ops.get(event, "ID") == :delete
           if params == [] || !IscsiClientLib.connected(true)
-            cmd = IscsiClientLib.GetAdmCmd(
-              Builtins.sformat(
-                "-m node -T %1 -p %2 -I %3 --op=delete",
-                Ops.get(params, 1, "").shellescape,
-                Ops.get(params, 0, "").shellescape,
-                Ops.get(params, 2, "").shellescape
-              )
-            )
-            result = SCR.Execute(path(".target.bash_output"), cmd, {})
-            Builtins.y2milestone(result.inspect)
+            IscsiClientLib.removeRecord
             IscsiClientLib.readSessions
             initDiscoveredTable("")
             if selected != nil

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -282,6 +282,7 @@ module Yast
         0
       )
         UI.ChangeWidget(:initiator_name, :Enabled, false)
+        # Not sure if there is such a widget called :write
         UI.ChangeWidget(:write, :Enabled, false)
       end
 
@@ -342,6 +343,7 @@ module Yast
         IscsiClientLib.writeInitiatorName(
           Convert.to_string(UI.QueryWidget(:initiator_name, :Value))
         )
+        # Isn't this redundant with the code at IscsiClientLib.writeInitiatorName?
         if Stage.initial
           IscsiClientLib.restart_iscsid_initial
         else
@@ -533,7 +535,7 @@ module Yast
         ip = "[#{ip}]" # brackets needed around IPv6
       end
 
-      # store /etc/iscsi/iscsi.conf
+      # Store the content of /etc/iscsi/iscsi.conf into memory
       IscsiClientLib.getConfig
 
       auth_none = Convert.to_boolean(UI.QueryWidget(Id(:auth_none), :Value))
@@ -588,7 +590,7 @@ module Yast
       end
 
       IscsiClientLib.targets = IscsiClientLib.ScanDiscovered(trg_list)
-      # restore saved config
+      # Restore into iscsi.conf the configuration previously saved in memory
       IscsiClientLib.oldConfig
 
       success

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -218,53 +218,8 @@ module Yast
       event = deep_copy(event)
       address = Convert.to_string(UI.QueryWidget(:isns_address, :Value))
       port = Convert.to_string(UI.QueryWidget(:isns_port, :Value))
-      found_addr = false
-      found_port = false
-      tmp_config = []
 
-      Builtins.foreach(IscsiClientLib.getConfig) do |row|
-        if Ops.get_string(row, "name", "") == "isns.address"
-          Ops.set(row, "value", address)
-          found_addr = true
-        end
-        if Ops.get_string(row, "name", "") == "isns.port"
-          Ops.set(row, "value", port)
-          found_port = true
-        end
-        if (Ops.get_string(row, "name", "") == "isns.address" ||
-            Ops.get_string(row, "name", "") == "isns.port") &&
-            Ops.greater_than(Builtins.size(address), 0) &&
-            Ops.greater_than(Builtins.size(port), 0) ||
-            Ops.get_string(row, "name", "") != "isns.address" &&
-                Ops.get_string(row, "name", "") != "isns.port"
-          tmp_config = Builtins.add(tmp_config, row)
-        end
-      end
-      if Ops.greater_than(Builtins.size(address), 0) &&
-          Ops.greater_than(Builtins.size(port), 0)
-        if !found_addr
-          tmp_config = Builtins.add(
-            tmp_config,
-            "name"    => "isns.address",
-            "value"   => address,
-            "kind"    => "value",
-            "type"    => 1,
-            "comment" => ""
-          )
-        end
-        if !found_port
-          tmp_config = Builtins.add(
-            tmp_config,
-            "name"    => "isns.port",
-            "value"   => port,
-            "kind"    => "value",
-            "type"    => 1,
-            "comment" => ""
-          )
-        end
-      end
-
-      IscsiClientLib.setConfig(tmp_config)
+      IscsiClientLib.setISNSConfig(address, port)
       IscsiClientLib.oldConfig
       nil
     end

--- a/src/lib/y2iscsi_client/authentication.rb
+++ b/src/lib/y2iscsi_client/authentication.rb
@@ -1,0 +1,137 @@
+require "yast"
+
+# |***************************************************************************
+# |
+# | Copyright (c) [2023] SUSE LLC
+# | All Rights Reserved.
+# |
+# | This program is free software; you can redistribute it and/or
+# | modify it under the terms of version 2 of the GNU General Public License as
+# | published by the Free Software Foundation.
+# |
+# | This program is distributed in the hope that it will be useful,
+# | but WITHOUT ANY WARRANTY; without even the implied warranty of
+# | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# | GNU General Public License for more details.
+# |
+# | You should have received a copy of the GNU General Public License
+# | along with this program; if not, contact SUSE LLC
+# |
+# | To contact Novell about this file by physical or electronic mail,
+# | you may find current contact information at www.suse.com
+# |
+# |***************************************************************************
+
+require "yast2/secret_attributes"
+
+module Y2IscsiClient
+  # Class to represent the authentication information for discovery and login operations
+  #
+  # When performing any of the two mentioned operations, an iSCSI system can be optionally
+  # configured to request authentication between controllers (targets) and hosts (initiators) using
+  # CHAP (Challenge Handshake Authentication Protocol). There are three options:
+  #
+  # - No authentication. No usernames or passwords are needed.
+  # - CHAP authentication performed by the target. The target authenticates the initiator by sending
+  #   it a CHAP challenge. The initiator must know {#username} and {#password}.
+  # - Bidirectional CHAP authentication. The target authenticates the initiator as above and then
+  #   the initiator authenticates the target by sending it a CHAP challenge. In addition to knowing
+  #   the {#username} and {#password} for the first challenge, the initiator must set {#username_in}
+  #   and {#password_in} for the second one.
+  #
+  # In the yast2-iscsi-client source code, authentication is typically represented by one of these
+  # two forms:
+  #
+  # - Just like four separate strings representing the possible usernames and passwords.
+  # - Has a hash in which the keys correspond to the names typically used by Open-iscsi in its
+  #   configuration files: "authmethod" ("CHAP" or "None"), "username", "username_in",
+  #   "password" and "password_in".
+  #
+  # In both cases, empty strings are used to represent blank values. Leaving the corresponding
+  # username/password empty is the main mechanism used to indicate a given authentication direction
+  # (by target / by initiator) is not wanted.
+  #
+  # This class allows to encapsulates that information and the associated logic.
+  class Authentication
+    include Yast
+    include Yast::Logger
+    include Yast2::SecretAttributes
+
+    # @return [String] Username for the CHAP challenge during authentication by the target
+    attr_accessor :username
+
+    # @return [String] Username for the CHAP challenge during authentication by the initiator
+    attr_accessor :username_in
+
+    # @!attribute password
+    #   @return [String] Password for the CHAP challenge during authentication by the target
+    secret_attr :password
+
+    # @!attribute password_in
+    #   @return [String] Password for the CHAP challenge during authentication by the initiator
+    secret_attr :password_in
+
+    # Creates a new authentication object from a legacy YaST hash (see description of this class)
+    #
+    # @param values [Hash{String => String}]
+    def self.new_from_legacy(values)
+      auth = new
+      auth.initialize_from_legacy(values)
+      auth
+    end
+
+    # Constructor
+    def initialize
+      @username = ""
+      @username_in = ""
+      self.password = ""
+      self.password_in = ""
+    end
+
+    # @see .new_from_legacy
+    #
+    # @param values [Hash{String => String}]
+    def initialize_from_legacy(values)
+      # Ignore usernames and passwords if there is an explicit method and is not CHAP
+      return if present?(values["authmethod"]) && !values["authmethod"].casecmp?("CHAP")
+
+      @username = values["username"]
+      self.password = values["password"]
+
+      # Ignore authentication by initiator if authentication by target is not set
+      @username_in = values["username_in"]
+      self.password_in = values["password_in"]
+    end
+
+    # Whether CHAP authentication should be performed by the target
+    #
+    # CHAP authentication always implies authentication by target (authentication by initiator
+    # is an optional second layer on top).
+    #
+    # @return [Boolean]
+    def by_target?
+      present?(username) && present?(password)
+    end
+
+    alias_method :chap?, :by_target?
+
+    # Whether CHAP authentication should be performed by the initiator
+    #
+    # @return [Boolean]
+    def by_initiator?
+      # Authentication by initiator only makes sense in addition to authentication by target
+      return false unless by_target?
+
+      present?(username_in) && present?(password_in)
+    end
+
+  private
+
+    # Whether the given variable contains a non-blank string
+    #
+    # @return [Boolean]
+    def present?(attrib)
+      !attrib.nil? && !attrib.empty?
+    end
+  end
+end

--- a/src/lib/y2iscsi_client/authentication.rb
+++ b/src/lib/y2iscsi_client/authentication.rb
@@ -1,5 +1,3 @@
-require "yast"
-
 # |***************************************************************************
 # |
 # | Copyright (c) [2023] SUSE LLC
@@ -22,6 +20,7 @@ require "yast"
 # |
 # |***************************************************************************
 
+require "yast"
 require "yast2/secret_attributes"
 
 module Y2IscsiClient

--- a/src/lib/y2iscsi_client/config.rb
+++ b/src/lib/y2iscsi_client/config.rb
@@ -1,0 +1,145 @@
+require "yast"
+
+module Y2IscsiClient
+  # Class to represent the content of the main configuration file (/etc/iscsi/iscsid.conf)
+  class Config
+    include Yast
+    include Yast::Logger
+
+    # Path of the sendtargets authentication in the config file
+    DISCOVERY_AUTH = "discovery.sendtargets.auth".freeze
+    private_constant :DISCOVERY_AUTH
+
+    # Constructor
+    def initialize
+      @raw_data = {}
+    end
+
+    # Array with all the entries of the configuration
+    #
+    # Each entry is represented by hash that follows the structure of the yast init-agent.
+    #
+    # @return [Array<Hash>]
+    def entries
+      raw_data.fetch("value", [])
+    end
+
+    # Setter for #entries
+    #
+    # @param values [Array<Hash>]
+    def entries=(values)
+      raw_data["value"] = values
+    end
+
+    # Whether the object contains information obtained from a configuration file
+    #
+    # @return [Boolean]
+    def empty?
+      raw_data.empty?
+    end
+
+    # Load information from the system
+    def read
+      @raw_data = Yast::SCR.Read(path(".etc.iscsid.all"))
+      log.debug("read config #{raw_data}")
+    end
+
+    # Write configuration to the system
+    def save
+      Yast::SCR.Write(path(".etc.iscsid.all"), raw_data)
+      Yast::SCR.Write(path(".etc.iscsid"), nil)
+    end
+
+    # Modifies the needed entries in order to set the given configuration for discovery
+    # authentication
+    def set_discovery_auth(user_in, pass_in, user_out, pass_out)
+      if (!user_in.empty? && !pass_in.empty?)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.authmethod", "CHAP")
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.username_in", user_in)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.password_in", pass_in)
+      else
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.username_in")
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.password_in")
+      end
+
+      if (!user_out.empty? && !pass_out.empty?)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.authmethod", "CHAP")
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.username", user_out)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.password", pass_out)
+      else
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.username")
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.password")
+      end
+
+      if user_in.empty? && user_out.empty?
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.authmethod")
+      end
+    end
+
+    # Modifies the needed entries in order to set the given ISNS configuration
+    def set_isns(address, port)
+      if address.empty? || port.empty?
+        self.entries = delete(entries, "isns.address")
+        self.entries = delete(entries, "isns.port")
+      else
+        self.entries = set_or_add(entries, "isns.address", address)
+        self.entries = set_or_add(entries, "isns.port", port)
+      end
+    end
+
+  private
+
+    # Internal representation of the data
+    #
+    # Due to the way YaST ini-agent works, this variable follows the structure
+    # {"kind"=>"section", "type"=>-1, "value"=> Array<Hash> }
+    # in which that latter array of hashes represents the relevant entries in the
+    # configuration file.
+    #
+    # return [Hash]
+    attr_reader :raw_data
+
+    # Converts the given hash into the format needed by ini-agent
+    #
+    # @param old_map [Hash] hash with two keys "KEY" and "VALUE"
+    # @return [Hash]
+    def create_map(old_map)
+      {
+        "name"    => old_map.fetch("KEY", ""),
+        "value"   => old_map.fetch("VALUE", ""),
+        "kind"    => "value",
+        "type"    => 1,
+        "comment" => ""
+      }
+    end
+
+    # Modifies the value of the entry with the given name, creating a new entry if none exists
+    #
+    # @param old_list [Array<Hash>] list of maps in the format used by ini-agent (see {#create_map})
+    # @param key [String] name of the entry
+    # @param value [Object] new value for the entry
+    # @return [Array<Hash>] modified list of maps
+    def set_or_add(old_list, key, value)
+      new_list = deep_copy(old_list)
+
+      element = new_list.find { |row| row["name"] == key }
+      if element
+        element["value"] = value
+      else
+        new_list << create_map({ "KEY" => key, "VALUE" => value })
+      end
+
+      new_list
+    end
+
+    # Deletes the entry with the given key
+    #
+    # @param old_list [Array<Hash>] list of maps in the format used by ini-agent (see {#create_map})
+    # @param key [String] name of the entry to be deleted
+    # @return [Array<Hash>] modified list of maps
+    def delete(old_list, key)
+      log.info("Delete record for #{key}")
+      old_list.reject { |row| row["name"] == key }
+    end
+  end
+end

--- a/src/lib/y2iscsi_client/config.rb
+++ b/src/lib/y2iscsi_client/config.rb
@@ -52,27 +52,25 @@ module Y2IscsiClient
 
     # Modifies the needed entries in order to set the given configuration for discovery
     # authentication
-    def set_discovery_auth(user_in, pass_in, user_out, pass_out)
-      if (!user_in.empty? && !pass_in.empty?)
+    #
+    # @param auth [Authentication]
+    def set_discovery_auth(auth) # rubocop:disable Naming/AccessorMethodName
+      if auth.chap?
         self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.authmethod", "CHAP")
-        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.username_in", user_in)
-        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.password_in", pass_in)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.username", auth.username)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.password", auth.password)
       else
-        self.entries = delete(entries, "#{DISCOVERY_AUTH}.username_in")
-        self.entries = delete(entries, "#{DISCOVERY_AUTH}.password_in")
-      end
-
-      if (!user_out.empty? && !pass_out.empty?)
-        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.authmethod", "CHAP")
-        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.username", user_out)
-        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.password", pass_out)
-      else
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.authmethod")
         self.entries = delete(entries, "#{DISCOVERY_AUTH}.username")
         self.entries = delete(entries, "#{DISCOVERY_AUTH}.password")
       end
 
-      if user_in.empty? && user_out.empty?
-        self.entries = delete(entries, "#{DISCOVERY_AUTH}.authmethod")
+      if auth.by_initiator?
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.username_in", auth.username_in)
+        self.entries = set_or_add(entries, "#{DISCOVERY_AUTH}.password_in", auth.password_in)
+      else
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.username_in")
+        self.entries = delete(entries, "#{DISCOVERY_AUTH}.password_in")
       end
     end
 

--- a/src/lib/y2iscsi_client/timeout_process.rb
+++ b/src/lib/y2iscsi_client/timeout_process.rb
@@ -3,7 +3,7 @@ require "yast2/execute"
 
 Yast.import "Popup"
 
-# yast2 iscsi client specific namespace
+# Namespace for the YaST2 iSCSI client
 module Y2IscsiClient
   # Runner class that execute command with given timeout
   module TimeoutProcess

--- a/src/lib/y2iscsi_client/timeout_process.rb
+++ b/src/lib/y2iscsi_client/timeout_process.rb
@@ -12,9 +12,10 @@ module Y2IscsiClient
 
     # @param [Array<String>] command as list of arguments
     # @param [Integer] seconds timeout for command
+    # @param silent [Boolean] whether interaction with the user must be avoided
     # @return [Array(Boolean, Array<String>)] return pair of boolean if command
     #   succeed and stdout lines without ending newline
-    def self.run(command, seconds: 10)
+    def self.run(command, seconds: 10, silent: false)
       textdomain "iscsi-client"
 
       # pass kill-after to ensure that command really dies even if ignore TERM
@@ -28,10 +29,10 @@ module Y2IscsiClient
       case exit_status
       when 0 then [true, output]
       when 124, (128 + 9)
-        Yast::Popup.Error(_("Command timed out"))
+        Yast::Popup.Error(_("Command timed out")) unless silent
         [false, output]
       else
-        Yast::Popup.Error(stderr)
+        Yast::Popup.Error(stderr) unless silent
         [false, output]
       end
     end

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -819,9 +819,11 @@ module Yast
 
     # Delete the current node from the database of discovered targets
     #
-    # It does not check whether the node is connected. Bear in mind iscsiadm manpage states the
-    # following. "Delete should not be used on a running session. If it is iscsiadm will stop the
-    # session and then delete the record."
+    # It does not check whether the node is connected. Bear in mind the result in that case is
+    # uncertain. According to our manual tests, if you try to delete a node upon which a session is
+    # based, iscsiadm will refuse the request leaving the node entry in the database intact. On the
+    # other hand iscsiadm manpage states the following. "Delete should not be used on a running
+    # session. If it is iscsiadm will stop the session and then delete the record."
     #
     # @return [Boolean] whether the operation succeeded with no incidences
     def removeRecord

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -953,7 +953,14 @@ module Yast
         @currentRecord,
         check_ip
       )
-      ret = false
+      !!find_session(check_ip)
+    end
+
+    # Find the current record in the list of sessions
+    #
+    # @param check_ip [Boolean] whether the ip address must be considered in the comparison
+    # @return [String, nil] corresponding entry from #sessions or nil if not found
+    def find_session(check_ip)
       Builtins.foreach(@sessions) do |row|
         ip_ok = true
         list_row = Builtins.splitstring(row, " ")
@@ -973,11 +980,11 @@ module Yast
         if Ops.get(list_row, 1, "") == Ops.get(@currentRecord, 1, "") &&
             Ops.get(list_row, 2, "") == Ops.get(@currentRecord, 2, "") &&
             ip_ok
-          ret = true
-          raise Break
+          return row
         end
       end
-      ret
+
+      nil
     end
 
     # change startup status (manual/onboot) for target

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -918,6 +918,17 @@ module Yast
       status
     end
 
+    # Default startup status (manual/onboot/automatic) for newly created sessions
+    #
+    # @see #setStartupStatus
+    # @see #loginIntoTarget
+    #
+    # @return [String]
+    def default_startup_status
+      # Based on bnc#400610
+      "onboot"
+    end
+
     # update authentication value
     def setValue(name, value)
       rec = @currentRecord
@@ -1108,7 +1119,7 @@ module Yast
       # nowadays in YaST is to set the status twice with no benefit, first to "onboot" and then to
       # the value specified by the user. Nevertheless, we decided to keep the line to not alter the
       # behavior of loginIntoTarget, which is part of the module API.
-      setStartupStatus("onboot") if !Mode.autoinst
+      setStartupStatus(default_startup_status) if !Mode.autoinst
       true
     end
 

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -760,7 +760,7 @@ module Yast
     end
 
     # check initiatorname if exist, if no - create it
-    def checkInitiatorName
+    def checkInitiatorName(silent: false)
       ret = true
       file = "/etc/iscsi/initiatorname.iscsi"
       name_from_bios = getiBFT["iface.initiatorname"] || ""
@@ -809,14 +809,16 @@ module Yast
         )
         if Ops.greater_than(Builtins.size(name_from_bios), 0) &&
             name_from_bios != @initiatorname
-          Popup.Warning(
-            _(
-              "InitiatorName from iBFT and from <tt>/etc/iscsi/initiatorname.iscsi</tt>\n" \
-                "differ. The old initiator name will be replaced by the value of iBFT and a \n" \
-                "backup created. If you want to use a different initiator name, change it \n" \
-                "in the BIOS.\n"
+          if !silent
+            Popup.Warning(
+              _(
+                "InitiatorName from iBFT and from <tt>/etc/iscsi/initiatorname.iscsi</tt>\n" \
+                  "differ. The old initiator name will be replaced by the value of iBFT and a \n" \
+                  "backup created. If you want to use a different initiator name, change it \n" \
+                  "in the BIOS.\n"
+              )
             )
-          )
+          end
           Builtins.y2milestone(
             "replacing old name %1 by name %2 from iBFT",
             @initiatorname,

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -782,7 +782,12 @@ module Yast
       ret
     end
 
-    # delete deiscovered target from database
+    # Logout from the target (ie. remove the corresponding session)
+    #
+    # This does not delete the target from nodes database. The name of the method is plain wrong
+    # for historical reasons.
+    #
+    # To delete a record from the database of discovered targets, see {#removeRecord} instead.
     def deleteRecord
       ret = true
       Builtins.y2milestone("Delete record %1", @currentRecord)
@@ -807,6 +812,26 @@ module Yast
 
       readSessions
       ret
+    end
+
+    # Delete the current node from the database of discovered targets
+    #
+    # It does not check whether the node is connected. Bear in mind iscsiadm manpage states the
+    # following. "Delete should not be used on a running session. If it is iscsiadm will stop the
+    # session and then delete the record."
+    def removeRecord
+      result = SCR.Execute(
+        path(".target.bash_output"),
+        GetAdmCmd(
+          Builtins.sformat(
+            "-m node -T %1 -p %2 -I %3 --op=delete",
+            Ops.get(@currentRecord, 1, "").shellescape,
+            Ops.get(@currentRecord, 0, "").shellescape,
+            Ops.get(@currentRecord, 2, "").shellescape
+          )
+        )
+      )
+      Builtins.y2milestone(result.inspect)
     end
 
     # Get info about current iSCSI node

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -1072,4 +1072,31 @@ describe Yast::IscsiClientLib do
       end
     end
   end
+
+  describe ".removeRecord" do
+    before do
+      Yast::IscsiClientLib.currentRecord = [
+        "192.168.1.20:3260", "iqn.2022-12.com.example:2b0b2b2b", "default"
+      ]
+
+      allow(Yast::SCR).to receive(:Execute).with(Yast::Path.new(".target.bash_output"), anything)
+        .and_return("exit" => exit_code, "stdout" => "", "stderr" => "")
+    end
+
+    context "if iscsiadm exit code is 0" do
+      let(:exit_code) { 0 }
+
+      it "returns true" do
+        expect(Yast::IscsiClientLib.removeRecord).to eq true
+      end
+    end
+
+    context "if iscsiadm exit code is different from 0" do
+      let(:exit_code) { 1 }
+
+      it "returns true" do
+        expect(Yast::IscsiClientLib.removeRecord).to eq false
+      end
+    end
+  end
 end

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -983,4 +983,93 @@ describe Yast::IscsiClientLib do
       end
     end
   end
+
+  describe ".connected" do
+    before do
+      Yast::IscsiClientLib.sessions = [
+        "192.168.1.10:3260 iqn.2022-12.com.example:2b0b2b2b default",
+        "192.168.1.11:3260 iqn.2023-12.com.example:2a0a2a3a default"
+      ]
+    end
+
+    context "if check_ip is true" do
+      let(:check_ip) { true }
+
+      it "returns true if address, port, target name and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:3260", "iqn.2022-12.com.example:2b0b2b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq true
+      end
+
+      it "returns false if only address, target name and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:6666", "iqn.2022-12.com.example:2b0b2b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq false
+      end
+
+      it "returns false if only port, target name and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.20:3260", "iqn.2022-12.com.example:2b0b2b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq false
+      end
+
+      it "returns false if only address, port and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:3260", "iqn.2021-11.com.example:1b0b1b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq false
+      end
+
+      it "returns false if only address, port and target name match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:3260", "iqn.2022-12.com.example:2b0b2b2b", "eth0"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq false
+      end
+    end
+
+    context "if check_ip is false" do
+      let(:check_ip) { false }
+
+      it "returns true if address, port, target name and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:3260", "iqn.2022-12.com.example:2b0b2b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq true
+      end
+
+      # If check_ip is false, the port is not checked
+      it "returns true if only address, target name and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:6666", "iqn.2022-12.com.example:2b0b2b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq true
+      end
+
+      # If check_ip is false, the address is not checked
+      it "returns true if only port, target name and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.20:3260", "iqn.2022-12.com.example:2b0b2b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq true
+      end
+
+      it "returns false if only address, port and interface match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:3260", "iqn.2021-11.com.example:1b0b1b2b", "default"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq false
+      end
+
+      it "returns false if only address, port and target name match with a session" do
+        Yast::IscsiClientLib.currentRecord = [
+          "192.168.1.10:3260", "iqn.2022-12.com.example:2b0b2b2b", "eth0"
+        ]
+        expect(Yast::IscsiClientLib.connected(check_ip)).to eq false
+      end
+    end
+  end
 end

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -445,20 +445,6 @@ describe Yast::IscsiClientLib do
           {
             "comment" => "",
             "kind"    => "value",
-            "name"    => "discovery.sendtargets.auth.username_in",
-            "type"    => 1,
-            "value"   => "incuser"
-          },
-          {
-            "comment" => "",
-            "kind"    => "value",
-            "name"    => "discovery.sendtargets.auth.password_in",
-            "type"    => 1,
-            "value"   => "incpass"
-          },
-          {
-            "comment" => "",
-            "kind"    => "value",
             "name"    => "discovery.sendtargets.auth.username",
             "type"    => 1,
             "value"   => "outuser"
@@ -469,6 +455,20 @@ describe Yast::IscsiClientLib do
             "name"    => "discovery.sendtargets.auth.password",
             "type"    => 1,
             "value"   => "outpass"
+          },
+          {
+            "comment" => "",
+            "kind"    => "value",
+            "name"    => "discovery.sendtargets.auth.username_in",
+            "type"    => 1,
+            "value"   => "incuser"
+          },
+          {
+            "comment" => "",
+            "kind"    => "value",
+            "name"    => "discovery.sendtargets.auth.password_in",
+            "type"    => 1,
+            "value"   => "incpass"
           }
         ]
       }
@@ -491,6 +491,140 @@ describe Yast::IscsiClientLib do
       expect(Yast::SCR).to receive(:Write)
         .with(etc_iscsid, nil).and_return(true)
       expect(subject.oldConfig).to eq(nil)
+    end
+  end
+
+  describe "#discover" do
+    let(:etc_iscsid_all) { Yast::Path.new ".etc.iscsid.all" }
+    let(:etc_iscsid)     { Yast::Path.new ".etc.iscsid" }
+    let(:host)           { "192.168.1.1" }
+    let(:port)           { "4321" }
+    let(:auth)           { Y2IscsiClient::Authentication.new }
+    let(:initial_config) do
+      {
+        "comment" => "",
+        "file"    => -1,
+        "kind"    => "section",
+        "name"    => "",
+        "type"    => -1,
+        "value"   => [
+          {
+            "kind"  => "value",
+            "name"  => "node.active_cnx",
+            "type"  => 1,
+            "value" => "1"
+          },
+          {
+            "kind"  => "value",
+            "name"  => "discovery.sendtargets.auth.authmethod",
+            "type"  => 1,
+            "value" => "CHAP"
+          }
+        ]
+      }
+    end
+
+    before do
+      allow(Yast::ModuleLoading).to receive(:Load)
+
+      allow(Yast::SCR).to receive(:Read).with(etc_iscsid_all).and_return(initial_config)
+      subject.getConfig
+
+      allow(Yast::SCR).to receive(:Write)
+      allow(Yast::SCR).to receive(:Write)
+      allow(Y2IscsiClient::TimeoutProcess).to receive(:run).and_return [true, []]
+    end
+
+    # Auxiliary function to make sense of the format used by .etc.iscsid.all
+    # @return [Hash]
+    def config_values(data)
+      data.values.last.map { |i| [i["name"], i["value"]] }.to_h
+    end
+
+    it "calls iscsiadm to perform discovery" do
+      expect(Y2IscsiClient::TimeoutProcess).to receive(:run) do |command|
+        expect(command).to start_with(["iscsiadm", "-m", "discovery", "-P", "1"])
+        expect(command).to include "#{host}:#{port}"
+      end.and_return [true, []]
+
+      Yast::IscsiClientLib.discover(host, port, auth)
+    end
+
+    it "passes :silent to TimeoutProcess if silent mode is requested" do
+      expect(Y2IscsiClient::TimeoutProcess).to receive(:run) do |_command, keyword_args|
+        expect(keyword_args[:silent]).to eq true
+      end.and_return [true, []]
+
+      Yast::IscsiClientLib.discover(host, port, auth, silent: true)
+    end
+
+    context "with no discovery authentication" do
+      it "first disables discovery authentication and later restores the initial config" do
+        expect(Yast::SCR).to receive(:Write) do |path, content|
+          expect(path).to eq etc_iscsid_all
+          config_keys = config_values(content).keys
+          expect(config_keys).to_not include("discovery.sendtargets.auth.authmethod")
+          expect(config_keys).to_not include("discovery.sendtargets.auth.username")
+          expect(config_keys).to_not include("discovery.sendtargets.auth.username_in")
+        end.ordered
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid, nil).ordered
+
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid_all, initial_config).ordered
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid, nil).ordered
+
+        Yast::IscsiClientLib.discover(host, port, auth)
+      end
+    end
+
+    context "with discovery authentication by the target" do
+      before do
+        auth.username = "noone"
+        auth.password = "secret"
+      end
+
+      it "first sets discovery authentication and later restores the initial config" do
+        expect(Yast::SCR).to receive(:Write) do |path, content|
+          expect(path).to eq etc_iscsid_all
+          config = config_values(content)
+          expect(config["discovery.sendtargets.auth.authmethod"]).to eq "CHAP"
+          expect(config["discovery.sendtargets.auth.username"]).to eq "noone"
+          expect(config["discovery.sendtargets.auth.password"]).to eq "secret"
+          expect(config.keys).to_not include("discovery.sendtargets.auth.username_in")
+        end.ordered
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid, nil).ordered
+
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid_all, initial_config).ordered
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid, nil).ordered
+
+        Yast::IscsiClientLib.discover(host, port, auth)
+      end
+    end
+
+    context "with bi-directional discovery authentication" do
+      before do
+        auth.username = "noone"
+        auth.password = "secret"
+        auth.username_in = "someone"
+        auth.password_in = "shared secret"
+      end
+
+      it "sets bi-directional discovery authentication and later restores the initial config" do
+        expect(Yast::SCR).to receive(:Write) do |path, content|
+          expect(path).to eq etc_iscsid_all
+          config = config_values(content)
+          expect(config["discovery.sendtargets.auth.authmethod"]).to eq "CHAP"
+          expect(config["discovery.sendtargets.auth.username"]).to eq "noone"
+          expect(config["discovery.sendtargets.auth.password"]).to eq "secret"
+          expect(config["discovery.sendtargets.auth.username_in"]).to eq "someone"
+          expect(config["discovery.sendtargets.auth.password_in"]).to eq "shared secret"
+        end.ordered
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid, nil).ordered
+
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid_all, initial_config).ordered
+        expect(Yast::SCR).to receive(:Write).with(etc_iscsid, nil).ordered
+
+        Yast::IscsiClientLib.discover(host, port, auth)
+      end
     end
   end
 

--- a/test/y2iscsi_client/timeout_process_test.rb
+++ b/test/y2iscsi_client/timeout_process_test.rb
@@ -18,10 +18,17 @@ describe Y2IscsiClient::TimeoutProcess do
     context "when command failed" do
       # a command that produces stdout AND stderr AND fails
       let(:command) { ["sh", "-c", "echo Copying data; echo >&2 Giving up; false"] }
+
       it "shows error popup with its stderr" do
         expect(Yast::Popup).to receive(:Error).with("Giving up\n")
 
         described_class.run(command)
+      end
+
+      it "does not show any popup if silent mode was requested" do
+        expect(Yast::Popup).to_not receive(:Error)
+
+        described_class.run(command, silent: true)
       end
 
       it "returns false and its stdout" do
@@ -33,10 +40,16 @@ describe Y2IscsiClient::TimeoutProcess do
       # a command that produces stdout AND stderr AND takes a long time
       let(:command) { ["sh", "-c", "echo Copying data; echo >&2 Mars is too far; sleep 999"] }
 
-      it "shows generic error popup" do
+      it "shows generic error popup if silent mode was not requested" do
         expect(Yast::Popup).to receive(:Error).with("Command timed out")
 
         described_class.run(command, seconds: 1)
+      end
+
+      it "does not show any popup if silent mode was requested" do
+        expect(Yast::Popup).to_not receive(:Error)
+
+        described_class.run(command, seconds: 1, silent: true)
       end
 
       it "returns false and its stdout" do


### PR DESCRIPTION
## Problem

Responsibilities are not properly distributed in the yast-iscsi-client code.

- The UI takes care of things that should be done by `IscsiClientLib` (eg. discovering iSCSI nodes or deleting nodes from the database).
- `IscsiClientLib` often communicate directly with the user via pop-up messages.
- The logic to deal with CHAP authentication is spread all over the code and repeated over and over.

That makes impossible to write new code that relies on `IscsiClientLib` to offer a new interface for iSCSI configuration. And that's exactly what we want to do in D-Installer.

## Solution

Do the minimal changes in the code to allow all the basic operations to be performed relying only on `IscsiClientLib`  in a way it's independent from the YaST UI. That consist on two facets:

- Extended `IscsiClientLib` with new methods: `discover`, `remove_record`, `find_session` and `login_into_current`.
- Added a `:silent` optional argument to the following `IscsiClientLib` methods: `checkInitiatorName`, `discover` and `login_into_current`. That makes it possible to optionally suppress the pop-ups while keeping the original behavior by default.

Bonus: added quite some documentation to the code
Bonus: some code extracted to independent classes like `Config` or `Authentication`. The latter includes extensive information about the iSCSI authentication process, including details that were impossible to infer from the previous code or UI.

## Testing

- Manually tested all operations
- Added unit tests to the previously existing methods, to ensure backwards compatibility

## Note

Pull request separated into self-contained commits for easier review.