### PR TITLE
Add Support Packages on Demand [SLE-15-SP6]

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,7 +1,14 @@
 -------------------------------------------------------------------
+Tue Sep 19 14:01:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Add support packages on demand (bsc#1214273)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.0
 
 -------------------------------------------------------------------
 Thu Feb 10 16:29:34 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only


### PR DESCRIPTION
### Target Branch

_**This the merge of PR #125 into SLE-15-SP6**_. 


## Trello

https://trello.com/c/UoVA6ohy/


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1214273
"YaST iSCSI initiator setup failing on startup"

_Notice that the repo / package name for this is `yast-iscsi-client`._

## Problem

Crash when starting the _YaST iSCSI initiator_ (YaST iSCSI client) module.

## Cause

No _iscsiuio_ systemd service running, so it couldn't be detected. The service was not running because the corresponding `iscsiuio` driver package was not installed, even though it was determined that it would have been needed for that setup.

The root cause was that there were many (too many) exceptions when those support packages were not installed, and that customer had hit one of those cases.

This was initially an L3, but the L3 team advised the customer how to add the missing `iscsiuio` package manually, so the bug was downgraded from L3 to a normal bug.


## Fix

Now much simplifying the handling of installing the required support packages. The underlying library calls received much better support for all kinds of special cases and modes, so there is no more need to do it on the application level.

This now uses [`Package.CheckAndInstallPackagesInteractive()`](https://github.com/yast/yast-yast2/blob/master/library/packages/src/modules/Package.rb#L164).


## Special Cases and Modes

The [`Package`](https://github.com/yast/yast-yast2/blob/master/library/packages/src/modules/Package.rb) module is an abstraction layer above using _libzypp_ / the _package bindings_ directly. It has the concept of a _backend_ that is used to perform the actions, and that backend depends on the _modes_ (installation, normal use in the target system, AutoYaST installation, creating an AutoYaST profile (_config_ mode). The calling application no longer has to deal with all those modes and other flags; the _Package_ module is expected to do the right thing in each mode.


#### In the Target System a.k.a. Mode.normal

When started in the target system e.g. from the YaST control center, this checks if the required packages (_open-iscsi_ and, if appropriate, _iscsiuio_) are installed. If not, the user is asked for confirmation to install them. If the user denies the confirmation or if installing them fails, the user is asked for confirmation to either continue even though that may fail, or if the whole module should be aborted.

#### During Installation (First Stage) a.k.a. Stage.initial

The packages are added to the pool of packages that are to be installed. No further user interaction.


#### Installation Second Stage a.k.a. Stage.cont

Similar to _first stage_, but the libzypp target is initialized differently because it's no longer `/mnt`, it's `/` now because the target system is already booted.


#### AutoYaST Installation a.k.a. Mode.auto

The packages are added to the pool of packages that are to be installed. No further user interaction. Any errors are reported with the `Report` module to handle them as configured in the AutoYaST profile.


#### Creating an AutoYaST profile a.k.a. Mode.config

This uses the _PackageAI_ backend instead of actually installing the packages: The packages are added to the profile's package part. No further user interaction.


#### YaST Command Line

No or minimalistic interaction. Errors are reported using the _Report_ module.


## Related PRs

- Original for SLE-15-SP5: PR #125 
- master: _TBD_