### PR TITLE
Prevent Leaking Passwords to the Log

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 28 11:51:41 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't leak passwords to the log (bsc#1225432)
+- 5.0.2
+
+-------------------------------------------------------------------
 Tue Sep 19 14:01:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Add support packages on demand (bsc#1214273)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -419,7 +419,7 @@ module Yast
 
     # write temporary changed old config
     def oldConfig
-      Builtins.y2milestone("Store temporary config %1", @config)
+      Builtins.y2milestone("Store temporary config")
       @config.save
       nil
     end


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1225432


## Problem

Passwords may be leaked to the log


## Cause

When the configuration is written to file, it is also logged completely to the y2log. This includes any passwords that the user entered when configuring iSCSI.

Unfortunately, the config class is just a very thin wrapper around an array of hashes, not a real class with dedicated fields, so we cannot use the `secret_attr` method that we use in other places.


## Fix

Don't log the complete configuration, only the fact that is was written.

The log format is unwieldy and very hard to read for a human anyway, so it's not very useful to log it in the first place.