### PR TITLE
Fix read of sessions when auto login and start iscsiuio.service instead of socket (bsc#1228084)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Fri Sep 27 14:37:24 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixes for bsc#1228084:
+  - Inst client: Read sessions just after auto login in order to 
+    enable services at the end of the installation if needed 
+  - Finish client: enable iscsiuio.service instead of the socket
+- Use ip for reading the ip address of a given device instead of 
+  the deprecated ifconfig command
+- 4.6.3
+
+-------------------------------------------------------------------
 Tue May 28 13:05:18 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't leak passwords to the log (bsc#1225432)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/clients/inst_iscsi-client.rb
+++ b/src/clients/inst_iscsi-client.rb
@@ -75,6 +75,8 @@ module Yast
 
       # try auto login to target
       auto_login = IscsiClientLib.autoLogOn
+      # force a read of sessions in case of auto_login (bsc#1228084)
+      IscsiClientLib.readSessions if auto_login 
 
       # add package open-iscsi and iscsiuio to installed system
       iscsi_packages = ["open-iscsi", "iscsiuio"]

--- a/src/clients/inst_iscsi-client.rb
+++ b/src/clients/inst_iscsi-client.rb
@@ -76,7 +76,7 @@ module Yast
       # try auto login to target
       auto_login = IscsiClientLib.autoLogOn
       # force a read of sessions in case of auto_login (bsc#1228084)
-      IscsiClientLib.readSessions if auto_login 
+      IscsiClientLib.readSessions if auto_login
 
       # add package open-iscsi and iscsiuio to installed system
       iscsi_packages = ["open-iscsi", "iscsiuio"]

--- a/src/lib/y2iscsi_client/finish_client.rb
+++ b/src/lib/y2iscsi_client/finish_client.rb
@@ -106,7 +106,7 @@ module Y2IscsiClient
         return
       end
 
-      enable_socket_or_service("iscsiuio")
+      Yast::Service.Enable("iscsiuio")
     end
 
     # Enables the socket with the given name or the corresponding service if the socket

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1800,7 +1800,7 @@ module Yast
 
       return ipaddr if address_line.empty?
 
-      ipaddr = address_line.gsub!(/\s*inet /, "").split.first
+      ipaddr = address_line.gsub!(/\s*inet /, "").split("/").first
       log.info "IP Address for #{dev_name}: #{ipaddr}"
 
       ipaddr

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -954,12 +954,10 @@ describe Yast::IscsiClientLib do
             mock_ip_addr("p6p2_1", "10.11.12.13/24")
           end
 
-          # NOTE: this is likely an unwanted behavior caused by the fact that the code expects the
-          # output of ifconfig version 1.X, not the one in recent versions of (open)SUSE.
           it "sets the IPs in @offload_valid to 'unknown'" do
             subject.GetOffloadItems
             cards = subject.instance_variable_get("@offload_valid").values.flatten(1)
-            expect(cards.map(&:last)).to eq ["unknown", "unknown", "unknown"]
+            expect(cards.map(&:last)).to eq ["192.10.9.8", "unknown", "10.11.12.13"]
           end
         end
 

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -709,15 +709,15 @@ describe Yast::IscsiClientLib do
       it "returns data in form of a map " do
         allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
         allow(subject).to receive(:getFirmwareInfo)
-          .and_return("# BEGIN RECORD 2.0-872\n"\
-                     "iface.bootproto = STATIC\n"\
-                     "iface.transport_name = tcp\n"\
-                     "iface.hwaddress = 00:00:c9:b1:bc:7f\n"\
-                     "iface.initiatorname = iqn.2011-05.com.emulex:eraptorrfshoneport1\n"\
-                     "iface.ipaddress = 2620:0113:80c0:8000:000c:0000:0000:04dc\n"\
-                     "node.conn[0].address = 172.0.21.6\n"\
-                     "node.conn[0].port = 3260\n"\
-                     "node.name = iqn.1986-03.com.ibm:sn.135061874\n"\
+          .and_return("# BEGIN RECORD 2.0-872\n" \
+                     "iface.bootproto = STATIC\n" \
+                     "iface.transport_name = tcp\n" \
+                     "iface.hwaddress = 00:00:c9:b1:bc:7f\n" \
+                     "iface.initiatorname = iqn.2011-05.com.emulex:eraptorrfshoneport1\n" \
+                     "iface.ipaddress = 2620:0113:80c0:8000:000c:0000:0000:04dc\n" \
+                     "node.conn[0].address = 172.0.21.6\n" \
+                     "node.conn[0].port = 3260\n" \
+                     "node.name = iqn.1986-03.com.ibm:sn.135061874\n" \
                      "# END RECORD\n")
 
         ibft_data = subject.getiBFT
@@ -917,9 +917,9 @@ describe Yast::IscsiClientLib do
           mock_iscsi_offload("p6p1_1", false)
           mock_iscsi_offload("p6p2_1", true, "34:56:78:90:ab:cd")
 
-          mock_ifconfig("em1")
-          mock_ifconfig("em3")
-          mock_ifconfig("p6p2_1")
+          mock_ip_addr("em1")
+          mock_ip_addr("em3")
+          mock_ip_addr("p6p2_1")
         end
 
         include_examples "returns UI items"
@@ -937,7 +937,7 @@ describe Yast::IscsiClientLib do
           expect(ids).to contain_exactly("default", "all", "em1-bnx2i", "em3-bnx2i", "p6p2_1-qedi")
         end
 
-        context "and ifconfig is not found" do
+        context "and ip is not found" do
           # NOTE: testing the state of internal variables should be out of the scope of unit tests,
           # but we want to prove a point here (see next context right below)
           it "sets the IPs in @offload_valid to 'unknown'" do
@@ -947,11 +947,11 @@ describe Yast::IscsiClientLib do
           end
         end
 
-        context "and ifconfig is found" do
+        context "and ip is found" do
           before do
-            mock_ifconfig("em1",    "192.10.9.8")
-            mock_ifconfig("em3",    "")
-            mock_ifconfig("p6p2_1", "10.11.12.13")
+            mock_ip_addr("em1",    "192.10.9.8/24")
+            mock_ip_addr("em3",    "")
+            mock_ip_addr("p6p2_1", "10.11.12.13/24")
           end
 
           # NOTE: this is likely an unwanted behavior caused by the fact that the code expects the

--- a/test/mocking.rb
+++ b/test/mocking.rb
@@ -113,14 +113,15 @@ def mock_ip_addr(dev_name, ipaddr = nil)
   if ipaddr
     stdout << %(1: #{dev_name}: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
     link/ether a0:b1:c2:d3:f7:ca brd ff:ff:ff:ff:ff:ff
-    altname enp5s0)
+    altname enp5s0\n)
     unless ipaddr.empty?
-      ip = IPAddr.new(ipaddr)
-      stdout << %(    inet #{ip}/#{ip.prefix} brd #{ip.to_range.last} scope global dynamic noprefixroute eth0
-          valid_lft 80637sec preferred_lft 80637sec)
+      netmask = IPAddr.new(ipaddr)
+      ip = IPAddr.new(ipaddr.split("/").first)
+      stdout << %(    inet #{ip}/#{netmask.prefix} brd #{netmask.to_range.last} scope global dynamic noprefixroute #{dev_name}
+          valid_lft 80637sec preferred_lft 80637sec\n)
     end
     stdout << %(    inet6 fe80::2897:6c42:202:21d7/64 scope link noprefixroute
-        valid_lft forever preferred_lft forever)
+        valid_lft forever preferred_lft forever\n)
   else
     exit_code = 127
     stderr = "No such file or directory - ip\n"

--- a/test/y2iscsi_client/finish_client_test.rb
+++ b/test/y2iscsi_client/finish_client_test.rb
@@ -170,73 +170,38 @@ describe Y2IscsiClient::FinishClient do
           allow(Yast2::Systemd::Socket).to receive(:find).with("iscsiuio").and_return(uio_socket)
         end
 
-        context "and there is an iscsiuio socket" do
-          let(:uio_socket) { instance_double(Yast2::Systemd::Socket) }
+        let(:uio_socket) { instance_double(Yast2::Systemd::Socket) }
 
-          context "but the iscsid socket does not exist" do
-            let(:iscsid_socket) { nil }
+        context "but the iscsid socket does not exist" do
+          let(:iscsid_socket) { nil }
 
-            it "enables the iscsid and iscsi services and the iscsiuio socket" do
-              expect(Yast::Service).to receive(:Enable).with("iscsid")
-              expect(Yast::Service).to receive(:Enable).with("iscsi")
-              expect(uio_socket).to receive(:enable)
-              subject.write
-            end
-
-            it "it does not enable the iscsiuio service" do
-              allow(uio_socket).to receive(:enable)
-              expect(Yast::Service).to_not receive(:Enable).with("iscsiuio")
-              subject.write
-            end
+          it "enables the iscsid, iscsi and iscsiuio services" do
+            expect(Yast::Service).to receive(:Enable).with("iscsid")
+            expect(Yast::Service).to receive(:Enable).with("iscsi")
+            expect(Yast::Service).to receive(:Enable).with("iscsiuio")
+            subject.write
           end
 
-          context "and also an iscsid socket" do
-            let(:iscsid_socket) { instance_double(Yast2::Systemd::Socket, enable: true) }
-
-            it "enables the iscsid and iscsiuio sockets and the iscsi service" do
-              expect(Yast::Service).to receive(:Enable).with("iscsi")
-              expect(uio_socket).to receive(:enable)
-              expect(iscsid_socket).to receive(:enable)
-              subject.write
-            end
-
-            it "it does not enable the iscsiuio nor the iscsid services" do
-              allow(uio_socket).to receive(:enable)
-              expect(Yast::Service).to_not receive(:Enable).with("iscsiuio")
-              expect(Yast::Service).to_not receive(:Enable).with("iscsid")
-              subject.write
-            end
+          it "it does not enable the iscsiuio socket" do
+            expect(uio_socket).to_not receive(:enable)
+            subject.write
           end
         end
 
-        context "and there is no iscsiuio socket" do
-          let(:uio_socket) { nil }
+        context "and the iscsid socket exists" do
+          let(:iscsid_socket) { instance_double(Yast2::Systemd::Socket, enable: true) }
 
-          context "nor iscsid socket" do
-            let(:iscsid_socket) { nil }
-
-            it "enables the iscsid, iscsi and iscsiuio services" do
-              expect(Yast::Service).to receive(:Enable).with("iscsid")
-              expect(Yast::Service).to receive(:Enable).with("iscsi")
-              expect(Yast::Service).to receive(:Enable).with("iscsiuio")
-              subject.write
-            end
+          it "enables the iscsid socket and the iscsiuio and iscsi services" do
+            expect(Yast::Service).to receive(:Enable).with("iscsi")
+            expect(Yast::Service).to receive(:Enable).with("iscsiuio")
+            expect(iscsid_socket).to receive(:enable)
+            subject.write
           end
 
-          context "but there is an iscsid socket" do
-            let(:iscsid_socket) { instance_double(Yast2::Systemd::Socket, enable: true) }
-
-            it "enables the iscsi and iscsiuio services and the iscsid socket" do
-              expect(Yast::Service).to receive(:Enable).with("iscsi")
-              expect(Yast::Service).to receive(:Enable).with("iscsiuio")
-              expect(iscsid_socket).to receive(:enable)
-              subject.write
-            end
-
-            it "it does not enable the iscsid service" do
-              expect(Yast::Service).to_not receive(:Enable).with("iscsid")
-              subject.write
-            end
+          it "it does not enable the iscsid services" do
+            allow(Yast::Service).to receive(:Enable).with("iscsiuio")
+            expect(Yast::Service).to_not receive(:Enable).with("iscsid")
+            subject.write
           end
         end
       end


### PR DESCRIPTION
## Problem

When the iSCSI client is called during installation, it tries to do an auto login. This auto login call will add the nodes configurations provided by iBFT in case of present (iscsiadm -m discovery -t fw) but if the connected target tabs is not visited then the session is not read and the iscsi services are not activated at the end of the installation because the sessions are not populated properly.

It is not the only problem detected but also the discovery call is writing the nodes configuration persistently with the startup attribute as manual instead of onboot something that is not correct at all.

And last but not least the **iscsiuio.service** should be enabled independently of the socket one when it makes sense (offload supported / iBFT config).

- **Bug:** [bsc#1228084 ](https://bugzilla.suse.com/show_bug.cgi?id=1228084)
- **Trello Card:** [https://trello.com/c/Ckb1w6rF](https://trello.com/c/Ckb1w6rF/3732-3-sles15-sp6-p5-1228084-neither-iscsiuioservice-nor-iscsiuiosocket-are-enabled-after-iscsi-root-installation-on-bnx2i) 

## Solution

- Read the sessions during the installation just after the auto login if it succeeded.
- Enable iscsiuio.service when it is relevant instead of the socket.
- Fixed the method for obtaining the ip address of an specific device name as it was still relying on deprecated ifconfig command.
 
## Testing

- *Adapated unit tests*
- *Tested manually*

