### PR TITLE
Force a read of offload items in case of auto login

### DIFF
--- a/src/clients/inst_iscsi-client.rb
+++ b/src/clients/inst_iscsi-client.rb
@@ -76,7 +76,10 @@ module Yast
       # try auto login to target
       auto_login = IscsiClientLib.autoLogOn
       # force a read of sessions in case of auto_login (bsc#1228084)
-      IscsiClientLib.readSessions if auto_login
+      if auto_login
+        IscsiClientLib.readSessions
+        IscsiClientLib.GetOffloadModules(force: true)
+      end
 
       # add package open-iscsi and iscsiuio to installed system
       iscsi_packages = ["open-iscsi", "iscsiuio"]

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1495,8 +1495,9 @@ module Yast
     # corresponding entry at @offload.
     #
     # @return [Array<String>]
-    def GetOffloadModules
-      GetOffloadItems() if @offload_valid == nil
+    def GetOffloadModules(force: false)
+      @offload_valid = nil if force
+      GetOffloadItems() if @offload_valid.nil?
       modules = []
       Builtins.foreach(@offload_valid) do |i, _l|
         modules = Convert.convert(


### PR DESCRIPTION
## Problem

When an auto login is performed the OffloadItems were already populated before reading sessions and the selected Offload Card could be wrong


## Solution

Force a read of OffloadItems in  case of auto login.

