### PR TITLE
Iscsi offload changes

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Oct 31 11:46:26 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixes for bsc##1231385
+   - Do not call iscsi_offload.sh script anymore using the iscsi 
+     ifaces created by autoLogOn directly and exposing them in the
+     UI instead of the offload card selection.
+- 4.6.4
+
+-------------------------------------------------------------------
 Fri Sep 27 14:37:24 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixes for bsc#1228084:

--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Oct 31 11:46:26 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
-- Fixes for bsc##1231385
+- Fixes for bsc#1231385
    - Do not call iscsi_offload.sh script anymore using the iscsi 
      ifaces created by autoLogOn directly and exposing them in the
      UI instead of the offload card selection.

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.6.3
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/clients/inst_iscsi-client.rb
+++ b/src/clients/inst_iscsi-client.rb
@@ -69,12 +69,13 @@ module Yast
       )
       # check initiator name, create if not exists
       IscsiClientLib.checkInitiatorName
-
-      IscsiClientLib.getiBFT
       IscsiClientLib.LoadOffloadModules
+      IscsiClientLib.getiBFT
 
       # try auto login to target
       auto_login = IscsiClientLib.autoLogOn
+      # force a read of ifaces
+      IscsiClientLib.read_ifaces if auto_login
       # force a read of sessions in case of auto_login (bsc#1228084)
       IscsiClientLib.readSessions if auto_login
 

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -113,7 +113,7 @@ module Yast
             method(:handleIface),
             "symbol (string, map)"
           ),
-          "help"              => Ops.get_string(@HELPS, "initiator_name", "")
+          "help"              => @HELPS["initiator_name"].to_s
         },
         # table of connected targets
         "connected_table"  => {

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -83,12 +83,12 @@ module Yast
           "widget"            => :custom,
           "custom_widget"     => HBox(
             MinWidth(
-              16,
+              72,
               HBox(
                 # name of iscsi client (/etc/iscsi/initiatorname.iscsi)
                 TextEntry(Id(:initiator_name), _("&Initiator Name")),
                 MinWidth(
-                  8,
+                  36,
                   ComboBox(
                     Id(:iface),
                     Opt(:notify),

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -90,9 +90,9 @@ module Yast
                 MinWidth(
                   8,
                   ComboBox(
-                    Id(:iscsi_iface),
+                    Id(:iface),
                     Opt(:notify),
-                    _("i&SCSI Iface"),
+                    _("iSCSI I&face"),
                     []
                   )
                 )

--- a/src/include/iscsi-client/dialogs.rb
+++ b/src/include/iscsi-client/dialogs.rb
@@ -90,12 +90,9 @@ module Yast
                 MinWidth(
                   8,
                   ComboBox(
-                    Id(:offload_card),
+                    Id(:iscsi_iface),
                     Opt(:notify),
-                    # prefer to not translate 'Offload' unless there is a well
-                    # known word for this technology (it's special hardware
-                    # shifting load from processor to card)
-                    _("Offload Car&d"),
+                    _("i&SCSI Iface"),
                     []
                   )
                 )
@@ -113,7 +110,7 @@ module Yast
             "symbol (string, map)"
           ),
           "handle"            => fun_ref(
-            method(:handleOffload),
+            method(:handleIface),
             "symbol (string, map)"
           ),
           "help"              => Ops.get_string(@HELPS, "initiator_name", "")

--- a/src/include/iscsi-client/helps.rb
+++ b/src/include/iscsi-client/helps.rb
@@ -120,7 +120,10 @@ module Yast
           ),
         "initiator_name" => _(
           "<p><b>Initiator Name</b> is a value from <tt>/etc/iscsi/initiatorname.iscsi</tt>. \nIn case you have iBFT, this value will be added from there and you are only able to change it in the BIOS setup.</p>"
-        ),
+        ) +
+          _(
+            "<p><b>iSCSI Iface</b> allows to select an specific iSCSI iface to be used for discovering targets.</p>"
+          ),
         "isns"           => _(
           "If you want to use <b>iSNS</b> (Internet  Storage  Name Service) for discovering targets instead of the default SendTargets method,\nfill in the IP address of the iSNS server and port. The default port should be 3205.\n"
         ),

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -33,6 +33,8 @@ require "y2iscsi_client/authentication"
 
 module Yast
   module IscsiClientWidgetsInclude
+    include Logger
+
     def initialize_iscsi_client_widgets(_include_target)
       textdomain "iscsi-client"
       Yast.import "IP"
@@ -311,9 +313,9 @@ module Yast
 
     def handleIface(_key, event)
       if event["EventReason"].to_s == "ValueChanged" && event["ID"] == :iface
-        if iface_value != IscsiClientLib.iface
+        if iface_value != IscsiClientLib.selected_iface
           IscsiClientLib.iface = iface_value
-          log.info "handleIface iface: #{IscsiClientLib.iface}"
+          log.info "handleIface iface: #{IscsiClientLib.selected_iface}"
         end
       end
       nil

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -266,6 +266,7 @@ module Yast
 
     def iface=(iface)
       log.info "Selecting the iface: #{iface} cur:#{@iface}"
+      @iface = iface
     end
 
     # Create and return complete iscsciadm command by adding the string

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1214,17 +1214,13 @@ module Yast
         ifacepar << " " unless ifacepar.empty?
         ifacepar << "-I " << iface.shellescape
         ifaces << iface
-      end
 
-      @ay_settings.fetch("targets", []).each do |target|
         next if portals.include? target["portal"]
         SCR.Execute(
           path(".target.bash"),
           GetAdmCmd(%(-m discovery #{ifacepar} -t st -p #{target["portal"].shellescape}))
         )
         portals << target["portal"]
-      end
-      @ay_settings.fetch("targets", []).each do |target|
         log.info "login into target #{target}"
         loginIntoTarget(target)
         @currentRecord = [target["portal"], target["target"], target["iface"]]
@@ -1291,7 +1287,7 @@ module Yast
       files.each do |file|
         ls = SCR.Read(path(".target.string"), "/etc/iscsi/ifaces/#{file}").split("\n")
         log.info "InitIfaceFile file: #{file}\nInitIfaceFile ls: #{ls}"
-        ls.select! { |l| !l.start_with?(/\s*#/) }
+        ls.reject! { |l| l.start_with?(/\s*#/) }
         iface_name = ls.find { |l| l.include? "iface.iscsi_ifacename" }.to_s
         log.info "InitIfaceFile ls: #{iface_name}"
         next if iface_name.empty?

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -265,7 +265,8 @@ module Yast
     end
 
     def iface=(iface)
-      log.info "Selecting the iface: #{iface} cur:#{@iface}"
+      return if @iface == iface
+      log.info "Changing the iface from #{iface} to #{@iface}"
       @iface = iface
     end
 

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1372,7 +1372,7 @@ module Yast
     # @param ip [String] Portal IP address
     # @param port [String] Portal port number
     # @param use_fw [Boolean] whether the target should be fw or not
-    # @only_new [Boolean] whether a new record should be created
+    # @param only_new [Boolean] whether a new record should be created
     # @return [Array<String>]
     def GetDiscoveryCmd(ip, port, use_fw: false, only_new: false)
       log.info "GetDiscoveryCmd ip:#{ip} port:#{port} fw:#{use_fw} only new:#{only_new}"

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1214,7 +1214,10 @@ module Yast
         ifacepar << " " unless ifacepar.empty?
         ifacepar << "-I " << iface.shellescape
         ifaces << iface
+      end
 
+      # rubocop:disable Style/CombinableLoops
+      @ay_settings.fetch("targets", []).each do |target|
         next if portals.include? target["portal"]
         SCR.Execute(
           path(".target.bash"),
@@ -1226,6 +1229,7 @@ module Yast
         @currentRecord = [target["portal"], target["target"], target["iface"]]
         setStartupStatus(target.fetch("startup", "manual"))
       end
+      # rubocop:enable Style/CombinableLoops
       true
     end
 

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1549,40 +1549,6 @@ module Yast
       result
     end
 
-    # Configures iSCSI offload engines for the given cards
-    #
-    # Tries to create an open-iscsi interface definition for each of the given cards.
-    #
-    # @param cards [Array<String>] list of interface names
-    # @return [Hash{String => Hash}] results of the operation, keys are the names of the interfaces
-    #   and values the corresponding result as a hash with three fields: "exit" (0 means the
-    #   definition was created), "hwaddr" and "ntype".
-    def configure_offload_engines(cards)
-      offload_res = {}
-
-      cards.each do |dev_name|
-        cmd = "#{OFFLOAD_SCRIPT} #{dev_name.shellescape} | grep ..:..:..:.." # grep for lines containing MAC address
-        log.info "GetOffloadItems cmd #{cmd}"
-        out = SCR.Execute(path(".target.bash_output"), cmd)
-        # Example for output if offload is supported on interface:
-        # cmd: iscsi_offload eth2
-        # out: $["exit":0, "stderr":"", "stdout":"00:00:c9:b1:bc:7f ip \n"]
-        cmd2 = "#{OFFLOAD_SCRIPT} #{dev_name.shellescape}"
-        result = SCR.Execute(path(".target.bash_output"), cmd2)
-        log.info "GetOffloadItems iscsi_offload out:#{result}"
-
-        offload_res[dev_name] = {}
-        offload_res[dev_name]["exit"] = out["exit"]
-        next unless out["exit"].zero?
-
-        sl = Builtins.splitstring(out["stdout"], " \n")
-        offload_res[dev_name]["hwaddr"] = sl[0]
-        offload_res[dev_name]["ntype"] = sl[1]
-      end
-
-      offload_res
-    end
-
     # Current IP address of the given network interface
     def ip_addr(dev_name)
       stdout = Yast::Execute.on_target!("ip", "addr", "show", dev_name,

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1278,6 +1278,11 @@ module Yast
       content.find { |l| l.include? field }.to_s.gsub(/[[:space:]]/, "").split("=")[1]
     end
 
+    def read_ifaces
+      InitIfaceFile()
+      InitIface()
+    end
+
     def InitIfaceFile
       @iface_file = {}
       files = SCR.Read(path(".target.dir"), "/etc/iscsi/ifaces") || []
@@ -1476,10 +1481,7 @@ module Yast
     end
 
     def InitOffloadValid
-      if @iface_file.nil?
-        InitIfaceFile()
-        InitIface()
-      end
+      read_ifaces if @iface_file.nil?
 
       @offload_valid = potential_offload_cards
       card_names = @offload_valid.values.flatten(1).map { |c| c["iface"] }.uniq

--- a/test/data/chroot1/etc/iscsi/ifaces/bnx2i.ab:cd:de:fa:cf:29.ipv4.0
+++ b/test/data/chroot1/etc/iscsi/ifaces/bnx2i.ab:cd:de:fa:cf:29.ipv4.0
@@ -1,0 +1,26 @@
+# BEGIN RECORD 2.1.9
+iface.iscsi_ifacename = bnx2i.ab:cd:de:fa:cf:29.ipv4.0
+iface.net_ifacename = eth0
+iface.ipaddress = 192.168.100.29
+iface.prefix_len = 0
+iface.hwaddress = ab:cd:de:fa:cf:29
+iface.transport_name = bnx2i
+iface.initiatorname = iqn.2015-02.com.hpe:oneview-93044906-8f80-4d1a-9ddb-5f4a70cb47b4
+iface.vlan_id = 0
+iface.vlan_priority = 0
+iface.iface_num = 0
+iface.mtu = 0
+iface.port = 0
+iface.subnet_mask = 255.255.255.0
+iface.tos = 0
+iface.ttl = 0
+iface.tcp_wsf = 0
+iface.tcp_timer_scale = 0
+iface.def_task_mgmt_timeout = 0
+iface.erl = 0
+iface.max_receive_data_len = 0
+iface.first_burst_len = 0
+iface.max_outstanding_r2t = 0
+iface.max_burst_len = 0
+# END RECORD
+

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -805,7 +805,54 @@ describe Yast::IscsiClientLib do
     end
   end
 
-  describe ".GetOffloadItems" do
+  describe ".InitIfaceFile" do
+    around(:each) do |example|
+      # The directory /etc/iscsi/ifaces/ is always scanned to look for interface definitions,
+      # let's chroot the YaST agents so we can use an /etc directory with mocked content
+      root = File.join(File.dirname(__FILE__), "data", "chroot1")
+      change_scr_root(root, &example)
+    end
+
+    it "reads the existent iface files" do
+      expect(Yast::SCR).to receive(:Read).with(Yast.path(".target.dir"), "/etc/iscsi/ifaces").twice
+      subject.send(:InitIfaceFile)
+    end
+
+    context "there is no iface files" do
+      it "tries to generate them calling iscsiadm -m iface" do
+        expect(Yast::SCR).to receive(:Read).with(Yast.path(".target.dir"), "/etc/iscsi/ifaces").and_return([])
+        path = Yast::Path.new(".target.bash_output")
+        cmd = "LC_ALL=POSIX iscsiadm -m iface"
+        expect(Yast::SCR).to receive(:Execute).with(path, cmd)
+        allow(Yast::SCR).to receive(:Read).with(Yast.path(".target.dir"), "/etc/iscsi/ifaces").and_return([])
+        subject.send(:InitIfaceFile)
+      end
+    end
+
+    context "there are iface files" do
+      it "does not call iscsiadm -m iface" do
+        path = Yast::Path.new(".target.bash_output")
+        cmd = "LC_ALL=POSIX iscsiadm -m iface"
+        expect(Yast::SCR).to_not receive(:Execute).with(path, cmd)
+        subject.send(:InitIfaceFile)
+      end
+
+      it "populates the ifaces_file variable with the read data" do
+        iface_file = subject.instance_variable_get(:@iface_file)
+        expect(iface_file).to be_nil
+        subject.send(:InitIfaceFile)
+        iface_file = subject.instance_variable_get(:@iface_file)
+        iface, data = iface_file.first
+        expect(iface).to eq("bnx2i.ab:cd:de:fa:cf:29.ipv4.0")
+        expect(data[:name]).to eq("bnx2i.ab:cd:de:fa:cf:29.ipv4.0")
+        expect(data[:hwaddress]).to eq("ab:cd:de:fa:cf:29")
+        expect(data[:ip]).to eq("192.168.100.29")
+        expect(data[:transport]).to eq("bnx2i")
+      end
+    end
+  end
+
+  describe ".iface_items" do
     around(:each) do |example|
       # The directory /etc/iscsi/ifaces/ is always scanned to look for interface definitions,
       # let's chroot the YaST agents so we can use an /etc directory with mocked content
@@ -814,12 +861,6 @@ describe Yast::IscsiClientLib do
     end
 
     before do
-      # The agent .probe.netcard is used to inspect the network cards in the system, this
-      # intercepts that call and mocks the result based on the scenario we want to simulate
-      allow(Yast::SCR).to receive(:Read).and_call_original
-      allow(Yast::SCR).to receive(:Read).with(Yast::Path.new(".probe.netcard"))
-        .and_return probe_netcard
-
       # iscsiadm is always called, mock it to find no active ISCSI interfaces by default
       mock_iscsiadm_mode([])
     end
@@ -843,7 +884,7 @@ describe Yast::IscsiClientLib do
 
     RSpec.shared_examples "returns UI items" do
       it "returns an array of UI items" do
-        items = subject.GetOffloadItems
+        items = subject.iface_items
         expect(items).to be_an(Array)
         expect(items).to all be_a(Yast::Term)
         expect(items.map(&:value)).to all eq(:item)
@@ -852,132 +893,54 @@ describe Yast::IscsiClientLib do
 
     RSpec.shared_examples "only default" do
       it "provides 'default' as the only item" do
-        items = subject.GetOffloadItems
+        items = subject.iface_items
         expect(items.size).to eq 1
         expect(ui_item_label(items.first)).to eq "default (Software)"
         expect(ui_item_id(items.first)).to eq "default"
       end
     end
 
-    context "with no network cards in the system" do
-      let(:probe_netcard) { [] }
-
-      include_examples "returns UI items"
-      include_examples "only default"
-    end
-
-    context "with network cards not expected to support offloading" do
-      let(:probe_netcard) do
-        [
-          probed_card("enp0s1", "r8152", "12:34:56:78:90:ab"),
-          probed_card("enp5s6", "tg3", "23:45:67:89:0a:bc")
-        ]
+    context "with no iscsi ifaces in the system" do
+      before do
+        allow(Yast::SCR).to receive(:Read).with(Yast.path(".target.dir"), "/etc/iscsi/ifaces")
+        mock_bash_out(/iscsiadm -m iface/, { "exit" => 0, "stdout" => "", "stderr" => "" })
       end
 
       include_examples "returns UI items"
       include_examples "only default"
     end
 
-    context "with several network cards that could support offloading" do
-      let(:probe_netcard) do
-        [
-          probed_card("p6p1_1", "qede",  "12:34:56:78:90:ab"),
-          probed_card("em1",    "bnx2x", "23:45:67:89:0a:bc"),
-          probed_card("p6p2_1", "qede",  "34:56:78:90:ab:cd"),
-          probed_card("em2",    "bnx2x", "45:67:89:0a:bc:de"),
-          probed_card("em3",    "bnx2x", "56:78:90:ab:cd:ef")
-        ]
-      end
+    context "with iscsi ifaces in the system" do
+      include_examples "returns UI items"
 
-      context "if none of the cards support offloading" do
-        before do
-          mock_iscsi_offload("em1", false)
-          mock_iscsi_offload("em2", false)
-          mock_iscsi_offload("em3", false)
-          mock_iscsi_offload("p6p1_1", false)
-          mock_iscsi_offload("p6p2_1", false)
-        end
-
-        include_examples "returns UI items"
-
-        # NOTE: this is likely an unwanted behavior caused because
-        # @offload_valid == {2=>[], 7=>[]}
-        # which should be considered as an empty list but it's not
-        it "includes only 'default' and 'all'" do
-          labels = subject.GetOffloadItems.map { |i| ui_item_label(i) }
-          expect(labels).to contain_exactly("default (Software)", "all")
-        end
-      end
-
-      context "if some cards indeed support offloading" do
-        before do
-          mock_iscsi_offload("em1",    true, "23:45:67:89:0a:bc")
-          mock_iscsi_offload("em2",    false)
-          mock_iscsi_offload("em3",    true, "56:78:90:ab:cd:ef")
-          mock_iscsi_offload("p6p1_1", false)
-          mock_iscsi_offload("p6p2_1", true, "34:56:78:90:ab:cd")
-
-          mock_ip_addr("em1")
-          mock_ip_addr("em3")
-          mock_ip_addr("p6p2_1")
-        end
-
-        include_examples "returns UI items"
-
-        it "includes 'default', 'all' and an entry for each offload card" do
-          items = subject.GetOffloadItems
+      it "includes 'default', 'all' and an entry for each offload card" do
+          items = subject.iface_items
 
           labels = items.map { |i| ui_item_label(i) }
           expect(labels).to contain_exactly(
-            "default (Software)", "all", "em1 - 23:45:67:89:0a:bc - bnx2/bnx2i/bnx2x",
-            "em3 - 56:78:90:ab:cd:ef - bnx2/bnx2i/bnx2x", "p6p2_1 - 34:56:78:90:ab:cd - qede/qedi"
+            "default (Software)", "all", "bnx2i.ab:cd:de:fa:cf:29.ipv4.0 - 192.168.100.29"
           )
 
           ids = items.map { |i| ui_item_id(i) }
-          expect(ids).to contain_exactly("default", "all", "em1-bnx2i", "em3-bnx2i", "p6p2_1-qedi")
+          expect(ids).to contain_exactly("default", "all", "bnx2i.ab:cd:de:fa:cf:29.ipv4.0")
         end
+    end
 
-        context "and ip is not found" do
-          # NOTE: testing the state of internal variables should be out of the scope of unit tests,
-          # but we want to prove a point here (see next context right below)
-          it "sets the IPs in @offload_valid to 'unknown'" do
-            subject.GetOffloadItems
-            cards = subject.instance_variable_get("@offload_valid").values.flatten(1)
-            expect(cards.map(&:last)).to eq ["unknown", "unknown", "unknown"]
-          end
-        end
+    context "and no iscsi iface is reported by iscsiadm " do
+      before { mock_iscsiadm_mode([]) }
 
-        context "and ip is found" do
-          before do
-            mock_ip_addr("em1",    "192.10.9.8/24")
-            mock_ip_addr("em3",    "")
-            mock_ip_addr("p6p2_1", "10.11.12.13/24")
-          end
+      it "pre-selects the item 'default'" do
+        selected = subject.iface_items.find { |i| i.params[2] }
+        expect(ui_item_id(selected)).to eq "default"
+      end
+    end
 
-          it "sets the IPs in @offload_valid to 'unknown'" do
-            subject.GetOffloadItems
-            cards = subject.instance_variable_get("@offload_valid").values.flatten(1)
-            expect(cards.map(&:last)).to eq ["192.10.9.8", "unknown", "10.11.12.13"]
-          end
-        end
+    context "and one card is already associated to the first target" do
+      before { mock_iscsiadm_mode(["bnx2i.ab:cd:de:fa:cf:29.ipv4.0"]) }
 
-        context "and no active card is reported by iscsiadm " do
-          before { mock_iscsiadm_mode([]) }
-
-          it "pre-selects the item 'default'" do
-            selected = subject.GetOffloadItems.find { |i| i.params[2] }
-            expect(ui_item_id(selected)).to eq "default"
-          end
-        end
-
-        context "and one card is already associated to the first target" do
-          before { mock_iscsiadm_mode(["em3-bnx2i"]) }
-
-          it "selects by default the current offload card" do
-            selected = subject.GetOffloadItems.find { |i| i.params[2] }
-            expect(ui_item_id(selected)).to eq "em3-bnx2i"
-          end
-        end
+      it "selects by default the current iface" do
+        selected = subject.iface_items.find { |i| i.params[2] }
+        expect(ui_item_id(selected)).to eq "bnx2i.ab:cd:de:fa:cf:29.ipv4.0"
       end
     end
   end

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -914,16 +914,16 @@ describe Yast::IscsiClientLib do
       include_examples "returns UI items"
 
       it "includes 'default', 'all' and an entry for each offload card" do
-          items = subject.iface_items
+        items = subject.iface_items
 
-          labels = items.map { |i| ui_item_label(i) }
-          expect(labels).to contain_exactly(
-            "default (Software)", "all", "bnx2i.ab:cd:de:fa:cf:29.ipv4.0 - 192.168.100.29"
-          )
+        labels = items.map { |i| ui_item_label(i) }
+        expect(labels).to contain_exactly(
+          "default (Software)", "all", "bnx2i.ab:cd:de:fa:cf:29.ipv4.0 - 192.168.100.29"
+        )
 
-          ids = items.map { |i| ui_item_id(i) }
-          expect(ids).to contain_exactly("default", "all", "bnx2i.ab:cd:de:fa:cf:29.ipv4.0")
-        end
+        ids = items.map { |i| ui_item_id(i) }
+        expect(ids).to contain_exactly("default", "all", "bnx2i.ab:cd:de:fa:cf:29.ipv4.0")
+      end
     end
 
     context "and no iscsi iface is reported by iscsiadm " do

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -690,14 +690,14 @@ describe Yast::IscsiClientLib do
                   "\tPortal: 192.168.20.20:3260,2",
                   "\t\tIface Name: default",
                   "\tPortal: 192.168.10.20:3260,1",
-                  "\t\tIface Name: default"]
+                  "\t\tIface Name: bnx2i.9c:dc:71:df:cf:29.ipv4.0"]
         )).to eq(
           [
             "[2620:113:80c0:8080:e051:f9ea:73c7:9171]:3260 iqn.2013-10.de.suse:test_file2 default",
             "10.120.66.182:3260 iqn.2013-10.de.suse:test_file2 default",
             "[2620:113:80c0:8080:a00:27ff:fe1b:a7fe]:3260 iqn.2013-10.de.suse:test_file2 default",
             "192.168.20.20:3260 iqn.2018-06.de.suse.zeus:01 default",
-            "192.168.10.20:3260 iqn.2018-06.de.suse.zeus:01 default"
+            "192.168.10.20:3260 iqn.2018-06.de.suse.zeus:01 bnx2i.9c:dc:71:df:cf:29.ipv4.0"
           ]
         )
       end


### PR DESCRIPTION
## Problem

Bugzilla: [bsc#1231385](https://bugzilla.suse.com/show_bug.cgi?id=1231385)

In the "iSCSI initiator" dialog, the offload card was not displayed correctly. Instead of bnx2i, the dialog showed "default (TCP)". I'm not sure what would have happened if I hadn't changed this to bnx2i.

In the "iBFT" dialog, the bnx2i transport was displayed correctly.

## Solution

The selection of the offload card is relevant just in case we wanted to do some discover using that specific interface.

When a different offload card is selected it calls the iscsi_offload.sh script and select the related iscsi_iface to be used by discovery commands.

But the point is that the configuration is already done during in the initialization, so, doing it on selection doesn’t change anything at all.

What is even more important, the login and configuration most of the time is done automatically by firmware and the iscsi_offload script just creates redundant iscsi iface files… therefore, after some discussion it has been decided we could get rid of the script relying on the `iscsiadm -m fw -l` and `iscsiadm -m discovery -t` fw calls.

### Out of the scope (to improve in the future)

During the review and testing we found that there are some behavior / bugs that could be addressed but not as part of this bug:

- The iface selection should allow a multiselection.
- The iBFT tab shows only the configuration of one iface instead of the whole configuration.

## Testing

- *Tested manually*


## Screenshots

![image](https://github.com/user-attachments/assets/7e5738f7-12c2-4ded-935a-a09f7a9097e7)
