### PR TITLE
Fix typo when modifying the initiatorname (bsc#1233351) - master

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 14 09:13:29 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix typo introduced by previous change (bsc#1231385, bsc#1233351)
+- 5.0.5
+
+-------------------------------------------------------------------
 Thu Oct 31 11:46:26 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixes for bsc#1231385

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        5.0.4
+Version:        5.0.5
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/include/iscsi-client/widgets.rb
+++ b/src/include/iscsi-client/widgets.rb
@@ -252,7 +252,7 @@ module Yast
       #  "yyyy-mm" is the date at which the domain is valid and the identifier
       #  is freely selectable. For further details please check the iSCSI spec.
 
-      i_name = Convert.to_string(UI.QueryWidget(:initiator_name, :Value))
+      i_name = initiator_name_value
 
       # name not changed at all or already saved after checking it
       return true if IscsiClientLib.initiatorname == i_name
@@ -291,21 +291,22 @@ module Yast
       UI.QueryWidget(:iface, :Value).to_s
     end
 
+    def initiator_name_value
+      UI.QueryWidget(:initiator_name, :Value).to_s
+    end
+
     def storeInitName(_key, event)
       event = deep_copy(event)
-      if Convert.to_string(UI.QueryWidget(:initiator_name, :Value)) !=
-          IscsiClientLib.initiatorname
+      if initiator_name_value != IscsiClientLib.initiatorname
         # write initiatorname
-        IscsiClientLib.writeInitiatorName(
-          Convert.to_string(UI.QueryWidget(:initiator_name, :Value))
-        )
+        IscsiClientLib.writeInitiatorName(initiator_name_value)
         # Isn't this redundant with the code at IscsiClientLib.writeInitiatorName?
         if Stage.initial
           IscsiClientLib.restart_iscsid_initial
         else
           Service.Restart("iscsid")
         end
-        log.info "write initiatorname #{IscsientLib.initiatorname}"
+        log.info "write initiatorname #{IscsiClientLib.initiatorname}"
       end
       IscsiClientLib.iface = iface_value if iface_value != IscsiClientLib.selected_iface
       nil


### PR DESCRIPTION
It merges #140 into master.

Fix for https://bugzilla.suse.com/show_bug.cgi?id=1233351

