### PR TITLE
Get iBFT configuration in case of ARM architecture (bsc#1233802)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 22 16:31:35 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Try to load the iscsi_ibft module in ARM arch as it should be 
+  available for getting the iBFT configuration (bsc#1233802).
+- 4.6.6
+
+-------------------------------------------------------------------
 Thu Nov 14 09:13:29 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix typo introduced by previous change (bsc#1231385, bsc#1233351)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.6.5
+Version:        4.6.6
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -333,8 +333,9 @@ module Yast
       if @ibft == nil
         @ibft = {}
 
-        if !Arch.i386 && !Arch.x86_64
-          log.info "Because architecture #{Arch.arch_short} is different from x86, not using iBFT"
+        unless Arch.i386 || Arch.x86_64 || Arch.aarch64 || Arch.arm
+          log.info "iscsi_ibft module is not available for #{Arch.arch_short} Architecture"
+          log.info "not using iBFT"
           return @ibft
         end
         ret = SCR.Execute(path(".target.bash_output"),


### PR DESCRIPTION
## Problem

In **aarch64** we are not getting the **iBFT** configuration because an arch condition which exclude it.

- [*bsc#1233802*](https://bugzilla.suse.com/show_bug.cgi?id=1233802)

## Solution

Add arm and **aarch64** to the architectures supporting **iBFT** configuration.


