### PR TITLE
Fix the selection of potential offload cards (bsc#1236433)

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 31 15:53:50 UTC 2025 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Do not filter netcard cards by iscsioffload feature as for example
+  it is not present in qede/qedi devices (bsc#1236433).
+- 4.7.5
+
+-------------------------------------------------------------------
 Wed Jan 22 16:31:35 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Try to load the iscsi_ibft module in ARM arch as it should be 

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.7.4
+Version:        4.7.5
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1414,7 +1414,12 @@ module Yast
     #
     # @return [Boolean]
     def iscsiuio_relevant?
-      (ISCSIUIO_MODULES & GetOffloadModules()).any?
+      # qedi devices could not have any network device associated with it therefore reading the
+      # system netcard could be wrong and in that case we will check also the configured iscsi
+      # ifaces (bsc#1236433).
+      configured = (@iface_file || {}).values.map { |i| i[:transport] }.uniq
+
+      (ISCSIUIO_MODULES & (GetOffloadModules() | configured)).any?
     end
 
     # Loads the kernel modules needed to configure the iscsi client

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1523,7 +1523,7 @@ module Yast
     def potential_offload_cards
       # Store into hw_mods information about all the cards in the system
       cards = SCR.Read(path(".probe.netcard"))
-      hw_mods = cards.select { |c| c["iscsioffload"] }.map do |c|
+      hw_mods = cards.map do |c|
         log.info "GetOffloadItems card:#{c}"
         hw_mod = {
           "modules" => netcard_modules(c),


### PR DESCRIPTION
## Problem

Although a qedi device is configured by firmware and autoLogon success it is not listed as a potential offload card because the feature is not present.

- https://bugzilla.suse.com/show_bug.cgi?id=1236433

## Solution

Do not filter potential offload cards based on the iscsioffload feature but just based on the driver module and also check the transport name of the current iscsi files specially for qedi devices which could not have an associated network device obtained by hwinfo --netcard.
