### PR TITLE
Huha hide pw

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 23 10:38:00 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Ensure to hide passwords (bsc#1246833)
+- 4.7.6
+
+-------------------------------------------------------------------
 Fri Jan 31 15:53:50 UTC 2025 - Knut Alejandro Anderssen González <kanderssen@suse.com>
 
 - Do not filter netcard cards by iscsioffload feature as for example

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.7.5
+Version:        4.7.6
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -286,7 +286,7 @@ module Yast
     def hidePassword(orig)
       hidden = deep_copy(orig)
       hidden.each do |key, _value|
-        next unless key.include?("PASS")
+        next unless key =~ /pass/i
         hidden[key] = "*****"
       end
       hidden

--- a/test/iscsi_client_lib_test.rb
+++ b/test/iscsi_client_lib_test.rb
@@ -1060,4 +1060,23 @@ describe Yast::IscsiClientLib do
       end
     end
   end
+
+  describe "#hidePassword" do
+    let(:orig) do
+      {
+        "node.name"     => "my.node",
+        "harm.less"     => "harmless",
+        "auth.password" => "s3cr3t",
+        "auth.PASSWORD" => "s3cr3t"
+      }
+    end
+
+    it "hides passwords and only passwords" do
+      hidden = Yast::IscsiClientLib.hidePassword(orig)
+
+      expect(hidden["harm.less"]).to eq("harmless")
+      expect(hidden["auth.PASSWORD"]).not_to include("s3cr3t")
+      expect(hidden["auth.password"]).not_to include("s3cr3t")
+    end
+  end
 end


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1246833


## Problem

Passwords are shown in clear text on the "iBFT" page in the UI.


## Cause

The check for "PASS" was case-sensitive.