### PR TITLE
No iface bring up

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 19 10:52:39 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix the initialization of the valid iscsi offload cards not 
+  bringing up the network cards with an empty iface name 
+  (bsc#1246210).
+
+-------------------------------------------------------------------
 Wed Jul 23 10:38:00 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Ensure to hide passwords (bsc#1246833)

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        4.7.6
+Version:        4.7.7
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1484,16 +1484,24 @@ module Yast
     end
 
     def bring_up(card_names)
+      log.info "Bringing up #{card_names}"
+
       card_names.each { |n| Yast::Execute.locally!("ip", "link", "set", "dev", n, "up") }
     end
 
     def InitOffloadValid
       read_ifaces if @iface_file.nil?
+      card_names = []
 
       @offload_valid = potential_offload_cards
-      card_names = @offload_valid.values.flatten(1).map { |c| c["iface"] }.uniq
-      bring_up(card_names)
-      log.info "OffloadValid entries#{@offload_valid}"
+      @offload_valid.values.flatten(1).each do |card|
+        next if card["iface"].to_s.empty?
+        next if card_names.include? card["iface"]
+        card_names << card["iface"]
+      end
+
+      bring_up(card_names) unless card_names.empty?
+      log.info "OffloadValid entries: #{@offload_valid}"
       nil
     end
 


### PR DESCRIPTION
## Problem

There are  iscsi offload cards that does not have an associated network interface and therefore cannot be used as a regular network card. We should not try to bring up network interfaces without a name.

- https://trello.com/c/4l7Ie4CS
- https://bugzilla.suse.com/show_bug.cgi?id=1246210

## Solution

Skip unnamed interfaces from the list of network interfaces that need to be brought up.


