### PR TITLE
Remove counterproductive discovery command

### DIFF
--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Aug 28 17:31:40 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Do not perform an extra discovery during iBFT login, to prevent
+  the creation of problematic records at the node, interface and fw
+  databases (bsc#1247711).
+- 5.0.11
+
+-------------------------------------------------------------------
 Tue Aug 19 10:52:39 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix the initialization of the valid iscsi offload cards not 

--- a/package/yast2-iscsi-client.changes
+++ b/package/yast2-iscsi-client.changes
@@ -1,9 +1,11 @@
 -------------------------------------------------------------------
-Thu Aug 28 17:31:40 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+Mon Oct 20 10:16:23 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Do not perform an extra discovery during iBFT login, to prevent
   the creation of problematic records at the node, interface and fw
   databases (bsc#1247711).
+- Introduce a delay after iBFT login, to increase the chances of
+  libstorage-ng to properly detect the new devices (bsc#1247711).
 - 5.0.11
 
 -------------------------------------------------------------------

--- a/package/yast2-iscsi-client.spec
+++ b/package/yast2-iscsi-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-iscsi-client
-Version:        5.0.10
+Version:        5.0.11
 Release:        0
 Summary:        YaST2 - iSCSI Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1046,12 +1046,7 @@ module Yast
       if !getiBFT.empty?
         result = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m fw -l"))
         ret = false if result["exit"] != 0
-
-        # Note that fw discovery does not store persistent records in the node or discovery DB,
-        # so this is likely only done for reporting purposes (writing the info to the YaST logs)
         log.info "Autologin into iBFT : #{result}"
-        result = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m discovery -t fw"))
-        log.info "iBFT discovery: #{result}"
       end
       ret
     end

--- a/src/modules/IscsiClientLib.rb
+++ b/src/modules/IscsiClientLib.rb
@@ -1047,7 +1047,10 @@ module Yast
         result = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m fw -l"))
         ret = false if result["exit"] != 0
         log.info "Autologin into iBFT : #{result}"
+        # Give iSCSI some time, even if logon was not 100% successful
+        autologon_delay
       end
+      log.info "end of autoLogOn function"
       ret
     end
 
@@ -1616,6 +1619,32 @@ module Yast
       hwaddr = nil if hwaddr&.empty?
 
       [dev_name, hwaddr, type_label].compact.join(" - ")
+    end
+
+    # Method to be called after an iBFT login, to mitigate some known timing issues.
+    #
+    # See bsc#1247711 for some background.
+    #
+    # When this method is called, we are already logged into the iSCSI targets. But device detection
+    # in the kernel is asynchronous and the corresponding iSCSI devices may take some time to appear
+    # in the system. Moreover, there is no guarantee that the devices will all show up. According to
+    # a comment at bsc#1247711: "One or more paths being down is an acceptable situation. They
+    # may/should come up later, but there is no requirement that they be there at any given time".
+    #
+    # That could be a big problem for yast-storage-ng, which expects a complete and stable set of
+    # devices during its probing phase (eg. to properly detect multipath).
+    def autologon_delay
+      log.info "Giving some time to iSCSI"
+      sleep(10)
+      # Execute the following command just for logging purposes, it shows the relationship between
+      # existing sessions and kernel device names. Theoretically it could be used to detect whether
+      # all devices are available before the hard-coded delay of the previous line, but we decided
+      # to keep the code simple.
+      res = SCR.Execute(path(".target.bash_output"), GetAdmCmd("-m session -P3"))
+      log.info "iscsiadm result: #{res}"
+      # Invoking udevadm just in case some of the devices showed up but it is not ready yet.
+      # This probably makes no difference, but it will not hurt either.
+      Yast::Execute.locally("/usr/bin/udevadm", "settle", "--timeout=15")
     end
   end
 


### PR DESCRIPTION
## Problem 1

The process to automatically log into the iBFT nodes contained a call to this command.

```
iscsiadm -m discovery -t fw
```

Such a call was introduced at commit 14e6108c7bade6fcb8 in 2019. @wfeldt introduced it based on the content of the `iscsiadm` documentation, stating that "else iscsid returns no data". Although he was [not fully confident](https://github.com/yast/yast-iscsi-client/pull/78/files#r261611074)

I added a comment years later (commit 22889ff327) stating that such a call had no real effect in the system because, according to iscsiadm documentation, it didn't store persistent records in the node or discovery DB.

Turns out that both @wfeldt and myself were fooled by the wrong documentation of `iscsiadm`.

According to the reports of David Bond at [bsc#1247711](https://bugzilla.suse.com/show_bug.cgi?id=1247711), that command is actually building node, interface, and fw records in the iscsi database.

Those records are VERY problematic.

YaST has been affected for years. According to David: "_Looking back on the fact that I've had to clean out extra records from installs,, I now understand why.  In previous versions I did this on the iscsi dialog page by just deleting them during the install._".

Now Agama is also affected.

In short, iBFT systems configured by both YaST and Agama always need manual intervention to fix some messy behavior.

## Solution 1

Remove the call to `discovery` that was always incorrect and problematic.

## Problem 2

We are constantly having timing issues if the libstorage-ng probing happens immediately after the iBFT login. Some of the corresponding iSCSI devices has not yet appeared in the system. The problem is common to YaST and Agama, but more visible in the latter (since the iBFT login and the storage probing are closer in the workflow).

After a long conversation we didn't find any reliable way to detect when it was safe to proceed to the libstorage-ng probing.

## Solution 2

Simply introduce a hard-coded delay after the iBFT login operation.

## Testing

This fix has been tested by David Bond and seems to always result in a working system.